### PR TITLE
21 docker fix build env frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,8 @@ DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@db:5432/recipe_db
 
 # Frontend env
 # The value depends on where your backend is running.
-VITE_API_URL=/fastapi  # /fastapi for Production mode
+# VITE_API_URL=/fastapi               # Production mode
+VITE_API_URL=http://localhost:8000    # Dev mode
 
 # Backend env
 SQL_ECHO=1

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ POSTGRES_PASSWORD=recipe_pass123
 DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@db:5432/recipe_db
 
 # Frontend env
-VITE_API_URL=http://fastapi:8000
+# The value depends on where your backend is running.
+VITE_API_URL=/fastapi  # /fastapi for Production mode
 
 # Backend env
+SQL_ECHO=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,15 +35,16 @@ services:
     container_name: fastapi
     # image: fastapi
     build: fastapi/
-    # depends_on:
-    #   - db
     depends_on:
       db:
         condition: service_healthy
     networks: 
       - app-network
-    ports:
-      - "80"
+    # ports:
+    #   - "80"
+    # By removing the ports section from the base docker-compose.yml, 
+    # you ensure that only the ports from docker-compose.override.yml 
+    # (- "8000:80") are applied when you run docker compose up
     restart: always
     environment:
       DATABASE_URL: ${DATABASE_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,13 @@ services:
   frontend:
     build:
       context: ./frontend/
+      args:
+        # This maps .env variable to the Docker ARG
+        - VITE_API_URL=${VITE_API_URL}
     ports:
       - "8080:80"
     networks:
       - app-network
-    environment:
-        VITE_API_URL: ${VITE_API_URL}
     depends_on:
       - fastapi
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,98 +1,56 @@
 # Frontend
 
-## Makefile Shortcuts
-For more granular control of the frontend container without Compose, use the [frontend/Makefile](../frontend/Makefile):
+This document describes the architecture and technology stack of the frontend application.
 
-| Command | Purpose |
-| :--- | :--- |
-| `make build-dev` | Build the dev image |
-| `make run-dev` | Run dev server on port 5173 |
-| `make build-prod` | Build the Nginx production image |
-| `make run-prod` | Run prod Nginx on port 8080 |
+## Getting Started
+
+To run the project in development mode, execute this single command:
+
+```bash
+docker compose up --build
+```
+
+The application will then be available at [http://localhost:5173](http://localhost:5173).
 
 ---
 
-### Comparing Docker images for frontend:
+## 🛠️ Technology Stack
 
-```bash
-docker images recipes-frontend
-#Returns:
-REPOSITORY         TAG       IMAGE ID       CREATED             SIZE
-recipes-frontend   prod      4000e83b05bc   4 minutes ago       92.1MB
-recipes-frontend   builder   1ca82a22683c   10 minutes ago      1.08GB
-recipes-frontend   dev       268109152cf7   About an hour ago   1.07GB
-recipes-frontend   deps      7c177777c34c   3 hours ago         303MB
-```
----
-
-## How we created the Vite boilerplate?
-
-Install:
-
-```bash
-npm install react-router-dom @tanstack/react-query axios
-```
-
-These three cover **routing, data fetching, and API communication**.
-
-Typical modern stack:
+The core technologies used in this project are:
 
 | Category     | Package               | Purpose              |
 | ------------ | --------------------- | -------------------- |
-| Framework    | React                 | UI components        |
-| Routing      | react-router-dom      | Page navigation      |
-| Server state | @tanstack/react-query | API data management  |
-| HTTP client  | axios                 | API requests         |
-| Build tool   | Vite                  | Dev server + bundler |
+| **Framework** | **React**            | UI components |
+| **Routing** | **React Router** (react-router-dom) | Page navigation |
+| **Server state** | **TanStack Query** (@tanstack/react-query) | API data management |
+| **HTTP Client** | **Axios** | Sending HTTP requests to the backend |
+| **Build Tool**| **Vite** | Fast dev server and project bundling |
+| **UI Components** | **shadcn/ui** | Pre-built, styled, and accessible components |
+| **Styling** | **Tailwind CSS** | A utility-first CSS framework for styling |
 
 ---
 
-# Routing
+## 🏛️ Architecture Overview
 
-### React Router (`react-router-dom`)
+### Routing (React Router)
 
-**Purpose:** Navigation between pages.
+**Purpose:** Navigation between pages in a Single Page Application (SPA).
 
-Without it you cannot do:
+It allows creating routes like `/home`, `/recipes`, and `/recipes/123`.
 
-```
-/home
-/recipes
-/recipes/123
-/profile
-```
-
-Install:
-
-```bash
-npm install react-router-dom
-```
-
-Example:
-
+**Example:**
 ```javascript
 import { BrowserRouter, Routes, Route } from "react-router-dom"
 
 <BrowserRouter>
-  <Routes>
-    <Route path="/" element={<Home />} />
-    <Route path="/recipes" element={<Recipes />} />
-  </Routes>
+	<Routes>
+		<Route path="/" element={<Home />} />
+		<Route path="/recipes" element={<Recipes />} />
+	</Routes>
 </BrowserRouter>
 ```
 
-What it provides:
-
-* SPA navigation
-* dynamic routes (`/recipe/:id`)
-* protected routes
-* nested layouts
-
----
-
-# Server State (API Data)
-
-### TanStack Query (`@tanstack/react-query`)
+### Server State Management (TanStack Query)
 
 **Purpose:** Manage data coming from APIs.
 
@@ -101,8 +59,8 @@ Without it you would write a lot of messy code like:
 ```javascript
 useEffect(() => {
  fetch("/api/recipes")
-  .then(res => res.json())
-  .then(setRecipes)
+	.then(res => res.json())
+	.then(setRecipes)
 }, [])
 ```
 
@@ -115,45 +73,31 @@ Problems with this approach:
 
 React Query solves all that.
 
-Example:
-
+**Example:**
 ```javascript
 import { useQuery } from "@tanstack/react-query"
 
 const { data, isLoading } = useQuery({
-  queryKey: ["recipes"],
-  queryFn: fetchRecipes
+	queryKey: ["recipes"],
+	queryFn: fetchRecipes
 })
 ```
 
-Features:
+### API Client (Axios)
 
-* caching
-* background refetch
-* loading & error states
-* automatic retries
-* pagination
+**Purpose:** Send HTTP requests to your backend. We use Axios for its convenience compared to the native `fetch`.
 
----
-
-# API Client
-
-### Axios
-
-**Purpose:** Send HTTP requests to your backend.
-
-Example backend call:
-
+**Example:**
 ```javascript
 import axios from "axios"
 
 const api = axios.create({
-  baseURL: "http://localhost:3000/api"
+	baseURL: "http://localhost:8000/api" // URL of our FastAPI backend
 })
 
 export const fetchRecipes = async () => {
-  const res = await api.get("/recipes")
-  return res.data
+	const res = await api.get("/recipes")
+	return res.data
 }
 ```
 
@@ -168,9 +112,7 @@ Why Axios instead of `fetch`:
 
 ---
 
-# Build Tool
-
-### Vite
+### Build Tool (Vite)
 
 Purpose:
 
@@ -186,28 +128,16 @@ Features:
 | HMR             | instant updates |
 | smaller builds  | faster site     |
 
-Start dev server:
+### Tailwind CSS (Optional but very common)
 
-```bash
-npm run dev
-```
+**Purpose:** styling
 
----
-
-# (Optional but very common)
-
-### Tailwind CSS
-
-Purpose: styling
-
-Example:
-
+**Example:**
 ```html
 <button className="bg-blue-500 text-white px-4 py-2 rounded">
-  Save
+	Save
 </button>
 ```
-
 ---
 
 # Typical Folder Structure
@@ -216,78 +146,42 @@ Modern React apps usually look like this:
 
 ```
 src
- ├── api
+ ├── api								# Axios setup and fetch functions
  │    └── axios.js
- ├── components
- ├── pages
+ ├── components					# UI components (buttons, cards)
+ ├── pages							# Page components (Home, Recipes)
  │    ├── Home.jsx
  │    └── Recipes.jsx
- ├── hooks
- ├── routes
+ ├── hooks							# Custom hooks
+ ├── routes							# Routing configuration
  │    └── router.jsx
- ├── App.jsx
- └── main.jsx
+ ├── App.jsx						# Main application component
+ └── main.jsx						# Entry point where React is mounted to the DOM
 ```
 
 ---
 
-# Example Flow (Real App)
+### Example Flow (Real App)
 
-User opens:
+When a user opens the `/recipes` page:
 
-```
-/recipes
-```
-
-Flow:
-
-1️⃣ **React Router** loads the page
-2️⃣ **React Query** asks for recipes
-3️⃣ **Axios** calls the backend API
-4️⃣ Backend returns JSON
-5️⃣ React Query caches the result
-6️⃣ UI renders instantly
+1.  **React Router** loads the page
+2.  **React Query (TanStack)** initiates a request to fetch the recipes
+3.  **Axios** sends a GET request to the backend
+4.  The backend returns the data in JSON format
+5.  React Query (TanStack) caches the result and provides it to the component
+6.  The UI renders instantly
 
 ---
 
-# Full Install Command
+## Appendix: Boilerplate Creation Notes
 
-For a clean modern setup:
+This section documents the initial command used to add core dependencies after setting up the base Vite project.
+
+**Install Command:**
 
 ```bash
 npm install react-router-dom @tanstack/react-query axios
 ```
+
 ---
-
-
-### Install components
-
-Example:
-
-```bash
-npx shadcn@latest add button
-```
-
-This generates:
-
-```bash
-src/components/ui/button.jsx
-```
-
-Suggested basic components:
-
-```bash
-npx shadcn@latest add button
-npx shadcn@latest add card
-npx shadcn@latest add input
-npx shadcn@latest add dialog
-```
-
-## In Vite + React:
-
-index.html just has a <div id="root"></div> and a <script src="/src/main.tsx">.
-
-src/main.tsx renders your React tree into #root, usually <App />.
-
-Whatever <App /> returns is what you see in the browser.
-

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,8 +17,9 @@ CMD ["npm", "run", "dev", "--", "--host"]
 # ── Stage 3: build production assets ───────────────────────
 FROM deps AS builder
 COPY . .
-# ARG VITE_API_URL
+ARG VITE_API_URL
 ENV VITE_API_URL=$VITE_API_URL
+# Vite finds VITE_API_URL in the environment and bake it into the JavaScript code
 RUN npm run build
 
 # ── Stage 4: production runtime (tiny nginx image) ─────────

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -147,3 +147,19 @@ recipes-frontend   builder   1ca82a22683c   10 minutes ago      1.08GB
 recipes-frontend   dev       268109152cf7   About an hour ago   1.07GB
 recipes-frontend   deps      7c177777c34c   3 hours ago         303MB
 ```
+
+---
+
+## VITE_API_URL
+
+This variable is the “address” at which your frontend (the user's browser) will look for the backend. The value depends on where your backend is running.
+
+Rule: The value of `VITE_API_URL` should be an address that you can paste into the browser search bar and get a response from the API.
+
+Test VITE_API_URL
+
+You can verify it worked without even opening a browser. Just run this command to peek into your built JS files inside the container:
+
+```bash
+docker exec voice_chef_git-frontend-1 grep -r "fastapi" /usr/share/nginx/html
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,67 @@
 # React + TypeScript + Vite
 
+## Getting Started
+
+To run the project in development mode, execute this single command from the project root:
+
+```bash
+docker compose up --build
+```
+
+The application will then be available at [http://localhost:5173](http://localhost:5173).
+
+For local development without Docker, you can install dependencies and run the dev server directly:
+
+```bash
+npm install
+npm run dev
+```
+
+---
+
+## Makefile Shortcuts
+For more granular control of the frontend container without Compose, use the [frontend/Makefile](../frontend/Makefile):
+
+| Command | Purpose |
+| :--- | :--- |
+| `make build-dev` | Build the dev image |
+| `make run-dev` | Run dev server on port 5173 |
+| `make build-prod` | Build the Nginx production image |
+| `make run-prod` | Run prod Nginx on port 8080 |
+
+---
+
+## Working with shadcn/ui
+
+This section is a "how-to" guide specifically for the `shadcn/ui` library.
+
+`shadcn/ui` works differently from most UI libraries. Instead of installing a single package from `npm` and importing components from it, you use a command-line tool (`npx shadcn-ui@latest add ...`) to copy the source code of individual components (like `button`, `card`, `dialog`) directly into your project's src/components folder.
+
+Example:
+
+```bash
+npx shadcn@latest add button
+```
+
+This generates:
+
+```bash
+src/components/ui/button.jsx
+```
+
+Suggested basic components:
+
+```bash
+npx shadcn@latest add button
+npx shadcn@latest add card
+npx shadcn@latest add input
+npx shadcn@latest add dialog
+```
+
+---
+
+## Advanced Configuration
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:
@@ -7,11 +69,11 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
-## React Compiler
+### React Compiler
 
 The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
 
-## Expanding the ESLint configuration
+### Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
 
@@ -70,4 +132,18 @@ export default defineConfig([
     },
   },
 ])
+```
+
+---
+
+## Docker Image Reference
+
+```bash
+docker images recipes-frontend
+#Returns:
+REPOSITORY         TAG       IMAGE ID       CREATED             SIZE
+recipes-frontend   prod      4000e83b05bc   4 minutes ago       92.1MB
+recipes-frontend   builder   1ca82a22683c   10 minutes ago      1.08GB
+recipes-frontend   dev       268109152cf7   About an hour ago   1.07GB
+recipes-frontend   deps      7c177777c34c   3 hours ago         303MB
 ```

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,14 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
+import { 
+  Dialog, 
+  DialogTrigger, 
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription
+ } from "@/components/ui/dialog";
 
 // Note: MP. Test for VITE_API_URL
 import { fetchDbTables } from './api/axios';
@@ -18,7 +25,9 @@ function App() {
     const getTables = async () => {
       setLoading(true);
       const data = await fetchDbTables();
-      setTables(data.tables);
+      if (data && data.tables) {
+        setTables(data.tables);
+      }
       setLoading(false);
     };
 
@@ -62,7 +71,12 @@ function App() {
             <Button>Open dialog Button</Button>
           </DialogTrigger>
           <DialogContent>
-            This is a dialog content.
+            <DialogHeader>
+              <DialogTitle>Are you sure?</DialogTitle>
+              <DialogDescription>
+                This action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
           </DialogContent>
         </Dialog>
       </section>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,28 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
 
+// Note: MP. Test for VITE_API_URL
+import { fetchDbTables } from './api/axios';
+import { useState, useEffect } from 'react';
+
 function App() {
+
+  // State for storing the list of tables and the load status
+  const [tables, setTables] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // An effect that runs once when the component loads
+  useEffect(() => {
+    const getTables = async () => {
+      setLoading(true);
+      const data = await fetchDbTables();
+      setTables(data.tables);
+      setLoading(false);
+    };
+
+    getTables();
+  }, []);
+
   return (
     <div className="min-h-screen p-8 space-y-8">
       <h1 className="text-3xl font-bold">Component Gallery</h1>
@@ -44,6 +65,24 @@ function App() {
             This is a dialog content.
           </DialogContent>
         </Dialog>
+      </section>
+
+    {/* New block for displaying tables */}
+    <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Database Tables (from API)</h2>
+        <Card className="max-w-sm">
+          <CardContent className="p-6">
+            {loading ? (
+              <p>Loading tables...</p>
+            ) : (
+              <ul>
+                {tables.map((table) => (
+                  <li key={table} className="font-mono">{table}</li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
       </section>
     </div>
   );

--- a/frontend/src/api/axios.tsx
+++ b/frontend/src/api/axios.tsx
@@ -1,0 +1,28 @@
+// NOTE: MP. Test axios for API requestAnimationFrame
+
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default apiClient;
+
+interface TablesResponse {
+  tables: string[];
+}
+
+// Function to retrieve a list of tables
+export const fetchDbTables = async (): Promise<TablesResponse> => {
+  try {
+    const response = await apiClient.get<TablesResponse>('/tables');
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching DB tables:', error);
+    // Return an empty array if an error occurs
+    return { tables: [] };
+  }
+};

--- a/frontend/src/config.tsx
+++ b/frontend/src/config.tsx
@@ -1,5 +1,0 @@
-// NOTE: MP. Test file to test a VITE_API_URL
-
-export const API_URL = import.meta.env.VITE_API_URL;
-
-console.log('API URL from env:', API_URL);

--- a/frontend/src/config.tsx
+++ b/frontend/src/config.tsx
@@ -1,0 +1,5 @@
+// NOTE: MP. Test file to test a VITE_API_URL
+
+export const API_URL = import.meta.env.VITE_API_URL;
+
+console.log('API URL from env:', API_URL);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import './config.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,6 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
-import './config.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
**Fix the small issue with VITE_API_URL (frontend) in Production mode**

`VITE_API_URL` variable is the “address” at which the frontend (the user's browser) will look for the backend. During the production build (`npm run build`), Vite replaces all instances of `import.meta.env.VITE_API_URL` with its actual value, effectively baking it into the final JavaScript files.

**How to test it**

**Test 1**

Run the app in Prod mode. Run this command to peek into your built JS files inside the container:

`docker exec voice_chef_git-frontend-1 grep -r "fastapi" /usr/share/nginx/html`

The expected result is a very long string:

_"/usr/share/nginx/html/assets/[index-DaVO7PMo.js](http://index-davo7pmo.js/):For more information, see [https://radix-ui.com/primitives/docs/components/${f.docsSlug}`;return](https://radix-ui.com/primitives/docs/components/$%7Bf.docsSlug%7D%60;return) x.useEffect(()=>{i&&(document.getElementById(i)||console.error(r))},..."_ 

The `grep` command found your string and, as expected, printed the entire line of the file in which it found it.

**Test 2**

Open `http://localhost:8080/` in a browser. Below you will see the list of tables. I connected the frontend to the backend endpoint '/tables' to test that the `VITE_API_URL` value is correct.

**Why this works:**

1. Compose reads the `.env` file automatically.
2. The `${VITE_API_URL}` syntax in the args section pulls that value in.
3. The Dockerfile (frontend) "catches" it with `ARG`.
4. The `RUN npm run build` command sees that variable in the environment and replaces all instances of `import.meta.env.VITE_API_URL` in your code with the actual string.