### PR TITLE
get_db changed to get_session

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -29,7 +29,7 @@ def fetch_recipes(session: Session = Depends(get_session)):
     return recipes
 
 @app.get("/recipes/{recipe_id}")
-def get_recipe(recipe_id: UUID, session: Session = Depends(get_db)):
+def get_recipe(recipe_id: UUID, session: Session = Depends(get_session)):
     recipe = session.get(models.Recipe, recipe_id)
     if not recipe:
         raise HTTPException(status_code=404, detail="Recipe not found")


### PR DESCRIPTION
This pull request makes a minor update to the dependency used for database sessions in the `get_recipe` endpoint. The endpoint now uses the `get_session` dependency instead of `get_db`, which aligns it with the rest of the codebase and ensures consistent session management.