### PR TITLE
[frontend] a toast notification on signup error

### DIFF
--- a/frontend/office/package-lock.json
+++ b/frontend/office/package-lock.json
@@ -15,11 +15,13 @@
         "axios": "^1.13.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.2",
         "shadcn": "^4.0.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -7424,6 +7426,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -8647,6 +8659,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/frontend/office/package.json
+++ b/frontend/office/package.json
@@ -17,11 +17,13 @@
     "axios": "^1.13.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.2",
     "shadcn": "^4.0.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/frontend/office/src/components/signup-form.tsx
+++ b/frontend/office/src/components/signup-form.tsx
@@ -10,6 +10,7 @@ import {
   FieldSeparator,
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import { toast } from "sonner"
 
 import personImage from "@/assets/voice-chef-person.jpg"
 
@@ -24,7 +25,7 @@ async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
   const confirmPassword = formData.get("confirm-password") as string
 
   if (password !== confirmPassword) {
-    alert("Passwords do not match")
+    toast.error("Passwords do not match")
     return
   }
 
@@ -32,7 +33,7 @@ async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
   /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/
 
   if (!passwordRegex.test(password)) {
-    alert(
+    toast.error(
       "Password must be at least 8 characters and include letters, numbers, and symbols"
     )
     return
@@ -75,6 +76,9 @@ async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
         } else {
           errorDetails = String(errorField)
         }
+        toast.error("Registration error", {
+          description: errorDetails || "Something went wrong.",
+        })
       } catch {}
 
       const errorMessage = errorDetails
@@ -86,14 +90,21 @@ async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
 
     const data = await res.json()
     console.log("User created:", data)
-    alert("Account created successfully! Please log in.")
+    toast.success("Account created successfully! Please log in.")
 
     window.location.href = "/login"
 
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Signup failed"
     console.error(message)
-    alert(`Error: ${message}`)
+    // This toast is for the API error, but we can make it more user-friendly.
+    // The toast.error inside the `if (!res.ok)` block already shows the detailed message.
+    // This outer catch is now mainly for network errors or if the API response isn't valid JSON.
+    if (!message.includes("Signup failed (")) {
+        toast.error("An unexpected error occurred", {
+            description: message,
+        });
+    }
   }
 }
 

--- a/frontend/office/src/components/ui/sonner.tsx
+++ b/frontend/office/src/components/ui/sonner.tsx
@@ -1,0 +1,56 @@
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { CheckmarkCircle02Icon, InformationCircleIcon, Alert02Icon, MultiplicationSignCircleIcon, Loading03Icon } from "@hugeicons/core-free-icons"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: (
+          <HugeiconsIcon icon={CheckmarkCircle02Icon} strokeWidth={2} className="size-4" />
+        ),
+        info: (
+          <HugeiconsIcon icon={InformationCircleIcon} strokeWidth={2} className="size-4" />
+        ),
+        warning: (
+          <HugeiconsIcon icon={Alert02Icon} strokeWidth={2} className="size-4" />
+        ),
+        error: (
+          <HugeiconsIcon icon={MultiplicationSignCircleIcon} strokeWidth={2} className="size-4" />
+        ),
+        loading: (
+          <HugeiconsIcon icon={Loading03Icon} strokeWidth={2} className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+          // CSS Variables (Inline Styles)
+          "--error-bg": "#fef2f2",
+          "--error-text": "#000000",
+          "--error-border": "#fecaca",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+          // NOTE: mpeshko: we use the spread operator (...props.toastOptions?.classNames)
+          // to merge in any additional classNames passed down from the page (like 
+          // the error and title classes from SignupPage.tsx).
+          ...props.toastOptions?.classNames,
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/frontend/office/src/pages/SignupPage.tsx
+++ b/frontend/office/src/pages/SignupPage.tsx
@@ -1,5 +1,5 @@
 import { SignupForm } from "@/components/signup-form"
-
+import { Toaster } from "@/components/ui/sonner"
 
 export function SignupPage() {
   return (
@@ -7,6 +7,16 @@ export function SignupPage() {
       <div className="w-full max-w-sm md:max-w-4xl">
         <SignupForm />
       </div>
+      <Toaster
+        position="top-center"
+        richColors={true} // This flag tells the library: "Use color schemes for different types (success, error)."
+        toastOptions={{
+        classNames: {
+          title: 'font-semibold',
+          description: 'text-black',
+        },
+      }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Expected result

A "Toast" notification (pop-up window) in case of an invalid email or password.

<img width="651" height="406" alt="image" src="https://github.com/user-attachments/assets/91aa9499-ea5d-4c8e-9868-f1c57d3e868d" />

## Test

1. make dev
2. `http://localhost:5173/signup` in a browser
3. Use an invalid password. For example, `123`. You should see a "Toast" notification
4. Use an invalid email. For example, `blabla@123` . You should see a "Toast" notification

## Technical details

The toast UI component is an object from the shadcn library.

I installed it with the command:

`npx shadcn@latest add sonner`

You can find this component here: `frontend/office/src/components/ui/sonner.tsx`