### PR TITLE
Name and status filter – fix applied

### DIFF
--- a/backend/app/api/routes/recipe.py
+++ b/backend/app/api/routes/recipe.py
@@ -4,7 +4,6 @@ from sqlalchemy import inspect
 from sqlalchemy.orm import selectinload
 from app.core.database import get_session, engine
 from uuid import UUID
-from typing import Optional
 
 from app.core.pagination import pagination_params, PaginationParams, paginate
 from app.schemas.pagination import PaginatedResponse
@@ -58,9 +57,9 @@ def create_recipe(
 def retrieve_recipes(
     session: Session = Depends(get_session),
     pagination: PaginationParams = Depends(pagination_params),
-    status: Optional[str] = None,
-    search: Optional[str] = None,
-    name: Optional[str] = None,
+    status: str | None = None,
+    search: str | None = None,
+    name: str | None = None,
 ):
 
     query = select(Recipe)

--- a/backend/app/api/routes/recipe.py
+++ b/backend/app/api/routes/recipe.py
@@ -4,6 +4,7 @@ from sqlalchemy import inspect
 from sqlalchemy.orm import selectinload
 from app.core.database import get_session, engine
 from uuid import UUID
+from typing import Optional
 
 from app.core.pagination import pagination_params, PaginationParams, paginate
 from app.schemas.pagination import PaginatedResponse
@@ -56,9 +57,21 @@ def create_recipe(
 @router.get("", response_model=PaginatedResponse[Recipe])
 def retrieve_recipes(
     session: Session = Depends(get_session),
-    pagination: PaginationParams = Depends(pagination_params)):
+    pagination: PaginationParams = Depends(pagination_params),
+    status: Optional[str] = None,
+    search: Optional[str] = None,
+    name: Optional[str] = None,
+):
 
     query = select(Recipe)
+
+    if status:
+        query = query.where(Recipe.status == status.strip())
+
+    search_term = (search or name or "").strip()
+    if search_term:
+        query = query.where(Recipe.name.ilike(f"%{search_term}%"))
+
     recipes = paginate(query, session, pagination)
     return recipes
 

--- a/frontend/office/src/components/recipes/RecipeList.tsx
+++ b/frontend/office/src/components/recipes/RecipeList.tsx
@@ -22,17 +22,23 @@ function RecipeSkeleton() {
 
 export function RecipeList() {
   const navigate = useNavigate();
-  const [statusFilter, setStatusFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'draft' | 'active' | ''>('');
   const [nameFilter, setNameFilter] = useState('');
   const [page, setPage] = useState(0);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+
+  const statusOptions: Array<{ label: string; value: 'draft' | 'active' | '' }> = [
+    { label: 'All', value: '' },
+    { label: 'Draft', value: 'draft' },
+    { label: 'Active', value: 'active' },
+  ];
 
   const offset = page * PAGE_SIZE;
   const normalizedNameFilter = nameFilter.trim();
 
   const { data: recipePage, isLoading, isError, error } = useRecipes({
     ...(statusFilter ? { status: statusFilter } : {}),
-    ...(normalizedNameFilter ? { name: normalizedNameFilter } : {}),
+    ...(normalizedNameFilter ? { search: normalizedNameFilter } : {}),
     offset,
     limit: PAGE_SIZE,
   });
@@ -51,15 +57,22 @@ export function RecipeList() {
             setPage(0);
           }}
         />
-        <Input
-          placeholder="Filter by status (e.g. draft, active)…"
-          className="max-w-sm"
-          value={statusFilter}
-          onChange={(e) => {
-            setStatusFilter(e.target.value);
-            setPage(0);
-          }}
-        />
+        <div className="inline-flex items-center rounded-md bg-background p-1">
+          {statusOptions.map((option) => (
+            <Button
+              key={option.value || 'all'}
+              type="button"
+              variant={statusFilter === option.value ? 'default' : 'ghost'}
+              className="h-8 px-3"
+              onClick={() => {
+                setStatusFilter(option.value);
+                setPage(0);
+              }}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
         {!isInitialLoading && recipePage && (
           <span className="text-sm text-muted-foreground">
             {recipePage.meta.total} recipe{recipePage.meta.total !== 1 ? 's' : ''}


### PR DESCRIPTION
**The break was on the API side, not just the UI.** 
The Recipes page was sending filter values, but the /recipes route only paginated and never applied status or text filtering, so every request returned the same unfiltered slice.

Now fixed.