### PR TITLE
[feat/backend] POST /recipes adds ingredients + /ingredients/autocomplete

### DIFF
--- a/backend/app/api/routes/ingredient.py
+++ b/backend/app/api/routes/ingredient.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
+from sqlalchemy import func
 from app.core.database import get_session, engine
+from typing import List
 
 from app.core.pagination import pagination_params, PaginationParams, paginate
 from app.schemas.pagination import PaginatedResponse
@@ -11,6 +13,50 @@ from app.schemas.ingredient import IngredientWrite, IngredientResponse
 from app.schemas.pagination import PaginatedResponse
 
 router = APIRouter(prefix="/ingredients", tags=["Ingredients"])
+
+
+@router.get("/autocomplete", response_model=List[dict])
+def autocomplete_ingredients(
+    query: str = "",
+    limit: int = 10,
+    session: Session = Depends(get_session),
+):
+    """
+    Autocomplete (Typeahead) endpoint for ingredient search.
+    
+    Returns ingredients that START with the query (case-insensitive).
+    Optimized for fast typeahead responses.
+    """
+    
+    query = (query or "").lstrip()
+    limit = max(1, min(limit, 10))
+    
+    # Validate query length
+    if len(query) > 50:
+        raise HTTPException(
+            status_code=400, detail="Query must not exceed 50 characters"
+        )
+    
+    if len(query) < 1:
+        return []
+    
+    # Query: ingredients that START with the search term (word boundary)
+    ingredient_list = session.exec(
+        select(Ingredients).where(
+            Ingredients.name.ilike(f"{query}%")
+    #                                       ↑ SQL wildcard: matches anything after
+        )
+        .order_by(Ingredients.name.asc())
+        .limit(limit)
+    ).all()
+    
+    return [
+        {
+            "id": str(ingredient.id),
+            "name": ingredient.name,
+        }
+        for ingredient in ingredient_list
+    ]
 
 
 @router.get("", response_model=PaginatedResponse[Ingredients])
@@ -25,7 +71,7 @@ def retrieve_ingredient(
 
     normalized_search = (search or "").strip()
     if normalized_search:
-        query = query.where(Ingredients.name.ilike(f"%{normalized_search}%"))
+        query = query.where(Ingredients.name.ilike(f"{normalized_search}%"))
 
     normalized_source = (source or "").strip()
     if normalized_source:

--- a/backend/app/api/routes/recipe.py
+++ b/backend/app/api/routes/recipe.py
@@ -12,7 +12,8 @@ from app.core.pagination import (
 )
 from app.core.deps import get_current_user
 from app.utils.recipe_utils import (
-    to_recipe_detail, to_recipe_summary, ensure_unique_recipe_name
+    to_recipe_detail, to_recipe_summary, ensure_unique_recipe_name,
+    validate_recipe_business_rules
 )
 from app.models.recipe import Recipe
 from app.models.ingredient import Ingredient
@@ -111,6 +112,8 @@ def retrieve_recipe(
     return to_recipe_detail(recipe)
 
 
+# This function creates the many-to-many relationship between a recipe 
+# and its ingredients
 @router.post("", response_model=RecipeDetailResponse, status_code=201)
 def create_recipe(
     recipe: RecipeWrite,
@@ -118,25 +121,77 @@ def create_recipe(
     session: Session = Depends(get_session),
 ):
     tenant_id = current_user.tenant_id
-
     ensure_unique_recipe_name(session, recipe.name, tenant_id)
+    
+    # Validate business rules (Error 400 from api-spec)
+    validate_recipe_business_rules(recipe)
+    
     payload = recipe.model_dump(exclude={"ingredients"})
     payload["tenant_id"] = tenant_id
     new_recipe = Recipe(**payload)
+    ingredients_data = recipe.ingredients or []
 
-    # NOTE: mpeshko - try-catch block guarantees integrity in the presence 
-    # of concurrent queries (race conditions).
     try:
+        # Create and save recipe first
         session.add(new_recipe)
         session.flush()
+        
+        # Create ingredient links for each ingredient
+        # Loop through each ingredient
+        for ing_data in ingredients_data:
+            ingredient = session.get(Ingredient, ing_data.ingredient_id)
+            if not ingredient:
+                session.rollback()
+                raise HTTPException(
+                    status_code=404, 
+                    detail=f"Ingredient {ing_data.ingredient_id} not found"
+                )
+            
+            # Create recipe_ingredient link
+            recipe_ingredient = RecipeIngredient(
+                recipe_id=new_recipe.id,
+                ingredient_id=ing_data.ingredient_id,
+                quantity=ing_data.quantity,
+                unit=ing_data.unit,
+                preparation=ing_data.preparation,
+                sort_order=ing_data.sort_order
+            )
+            session.add(recipe_ingredient)
+        
         session.commit()
         session.refresh(new_recipe)
-    except IntegrityError:
+        
+        # Eagerly load ingredients for response
+        statement = (
+            select(Recipe)
+            .where(Recipe.id == new_recipe.id)
+            .options(
+                selectinload(Recipe.recipe_ingredients)
+                .selectinload(RecipeIngredient.ingredient)
+            )
+        )
+        new_recipe = session.exec(statement).first()
+        
+    except IntegrityError as e:
         session.rollback()
-        raise HTTPException(status_code=409, detail="Recipe name already exists")
+        raise HTTPException(
+            status_code=409, 
+            detail="Recipe name already exists or constraint violation"
+        )
+    except HTTPException:
+        raise  # Re-raise HTTPException (ingredient not found, 404)
+    except SQLAlchemyError as e:
+        session.rollback()
+        raise HTTPException(
+            status_code=500, 
+            detail="Internal server error while creating recipe"
+        )
     except Exception as e:
         session.rollback()
-        raise HTTPException(status_code=400, detail=f"Database error: {str(e)}")
+        raise HTTPException(
+            status_code=500, 
+            detail="Internal server error"
+        )
 
     return to_recipe_detail(new_recipe)
 
@@ -167,6 +222,9 @@ def update_recipe(
 
     for key, value in updates.items():
         setattr(recipe, key, value)
+    
+    # Validate business rules after applying updates
+    # validate_recipe_business_rules(recipe)
     
     try:
         session.add(recipe)

--- a/backend/app/schemas/recipe.py
+++ b/backend/app/schemas/recipe.py
@@ -29,8 +29,10 @@ class RecipeWrite(SQLModel):
     total_raw_weight_grams: Decimal | None = Field(default=None, ge=0)
     total_cooked_weight_grams: Decimal | None = Field(default=None, ge=0)
 
-    # ingredients: List[RecipeIngredientWrite] = []
-
+    # `default_factory` - it's essential for avoiding mutable default errors, 
+    # such as sharing the same list across instances.
+    ingredients: List[RecipeIngredientWrite] = Field(default_factory=list)
+    #                                          ↑ HAS default: OPTIONAL
 
 class RecipeIngredientResponse(SQLModel):
     id: UUID

--- a/backend/app/utils/recipe_utils.py
+++ b/backend/app/utils/recipe_utils.py
@@ -4,6 +4,38 @@ from fastapi import HTTPException, status
 from app.models.recipe import Recipe
 
 
+def validate_recipe_business_rules(recipe) -> None:
+    """
+    Validate recipe business rules before creation/update.
+    
+    Raises HTTPException(400) if any rule is violated.
+    """
+    # Rule 1: active + weight mode requires portion_size_grams > 0
+    if recipe.status == "active" and recipe.yield_mode == "weight":
+        if not recipe.portion_size_grams or recipe.portion_size_grams <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail="portion_size_grams is required and must be > 0 for active weight-mode recipes"
+            )
+    
+    # Rule 2: Negative totals not allowed
+    if recipe.total_raw_weight_grams and recipe.total_raw_weight_grams < 0:
+        raise HTTPException(
+            status_code=400,
+            detail="total_raw_weight_grams must not be negative"
+        )
+    if recipe.total_cooked_weight_grams and recipe.total_cooked_weight_grams < 0:
+        raise HTTPException(
+            status_code=400,
+            detail="total_cooked_weight_grams must not be negative"
+        )
+    if recipe.portions_count_resolved and recipe.portions_count_resolved <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail="portions_count_resolved must be greater than 0"
+        )
+
+
 def to_recipe_ingredient_response(link):
 
     ingredient = link.ingredient

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -399,6 +399,7 @@ MVP intents:
 | PATCH | `/recipes/{id}` | Bearer | Path: `id` UUID, Body: `RecipeUpdate` (partial merge) | `RecipeDetailResponse` | `200` | `400, 401, 404, 409, 422, 500` |
 | DELETE | `/recipes/{id}` | Bearer | Path: `id` UUID | none | `204` | `401, 404, 422, 500` |
 | GET | `/ingredients` | Bearer | Query: `limit`, `offset`, `ingredient_type`, `search`, `is_custom` | `{ items: IngredientResponse[], meta }` | `200` | `401, 422, 500` |
+| GET | `/ingredients/autocomplete` | Public | Query: `query`, `limit` | `[{ id, name }]` | `200` | `400, 422, 500` |
 | POST | `/ingredients` | Bearer | `IngredientWrite` | `IngredientResponse` | `201` | `400, 401, 409, 422, 500` |
 | GET | `/ingredients/{id}` | Bearer | Path: `id` UUID | `IngredientResponse` | `200` | `401, 404, 422, 500` |
 | PATCH | `/ingredients/{id}` | Bearer | Path: `id` UUID, Body: `IngredientUpdate` (partial merge) | `IngredientResponse` | `200` | `400, 401, 404, 409, 422, 500` |
@@ -562,6 +563,46 @@ Query Params:
 Success:
 - `200 OK`
 - Body: `{ items: IngredientResponse[], meta }`
+
+### 8b) GET `/ingredients/autocomplete`
+
+Purpose:
+- Fast typeahead/autocomplete suggestions for ingredient name search
+- Optimized for real-time UI input fields
+- Returns ingredients that **start with** the query term (word boundary matching)
+- No authentication required
+
+Query Params:
+- `query` optional string (min 1 char to return results, max 50)
+- `limit` optional int (default `10`, min `1`, max `10`)
+
+Success:
+- `200 OK`
+- Body: Array of suggestion objects
+
+```json
+[
+  {
+    "id": "1a6f300b-df96-49b7-a72d-f3004ce6dbf3",
+    "name": "Eier"
+  },
+  {
+    "id": "1a6f300b-df96-49b7-a72d-f3004ce6dbf4",
+    "name": "Eier Größe S"
+  }
+]
+```
+
+Behavior:
+- If `query` is empty or less than 1 character, returns `[]`
+- If `query` has results, returns up to `limit` items (capped at 10)
+- Results ordered alphabetically by ingredient name
+- Matches only ingredients where name **starts with** the query (case-insensitive)
+- Example: query `"eier"` matches `"Eier"`, `"Eier Größe S"`, but NOT `"Frischkäse mit Eiern"` (does not start with "eier")
+
+Errors:
+- `400` query longer than 50 characters
+- `422` invalid query parameters (non-integer limit)
 
 ### 9) POST `/ingredients`
 


### PR DESCRIPTION
## FEATURES

1. POST `/recipes` adds ingredients
2. new GET `/ingredients/autocomplete` for a future nice UX

---

## how to test POST `/recipes` in Swagger

**Step 1**: Open Swagger UI `http://localhost:8000/docs` and log in with **Authorize** button:
<img width="284" height="203" alt="image" src="https://github.com/user-attachments/assets/6a6ff865-181c-4021-be84-12d783154590" />

**Step 2**: Find POST `/recipes` Endpoint
Click on the POST /recipes endpoint to expand it.

**Step 3**: Test Request Body with Ingredients
Click "**Try it out**" and use this JSON:

{
  "name": "Potato Varenyky",
  "description": "Traditional Ukrainian Potato Varenyky",
  "instructions": "Step 1: Start the Dough\nIn a large bowl, combine an egg, water, and salt, and beat with a fork to dissolve the egg in the water.",
  "status": "draft",
  "yield_mode": "count",
  "portion_size_grams": 200,
  "portions_count_resolved": 5,
  "total_raw_weight_grams": 1200,
  "total_cooked_weight_grams": 1000,
  "preparation_time_minutes": 105,
  "cooking_time_minutes": 40,
  "is_component": false,
  "ingredients": [
    {
      "ingredient_id": "f662257f-5e60-5eb9-896a-bef62d61d485",
      "quantity": "50",
      "unit": "g",
      "preparation": "cooked",
      "sort_order": 1
    },
    {
      "ingredient_id": "ff640010-65e2-5acf-a739-2f8fab04c1a6",
      "quantity": "200",
      "unit": "g",
      "sort_order": 2
    }
  ]
}

**Step 5**: Click **Execute** button
Expected Response (200 Created). Ingredients are now included! 🍝 

**Common Errors**

400 Ingredient not found.  Cause: Fake ingredient_id 
500 Database error. Cause: Missing required fields 

**Step 5**: You can also test creating a recipe without ingredients (they're optional): 

{
  "name": "Simple Salad",
  "description": "Just vegetables",
  "status": "draft",
  "yield_mode": "count"
}

Response will have empty ingredients: []

---
## how to test GET `/ingredients/autocomplete` in a Terminal

1. 1 character
curl "http://localhost:8000/api/ingredients/autocomplete?query=e&limit=3"

# Response:
[
  {"id":"57951410-d49e-5588-a0b8-b64c7e26f08f","name":"E-100 Kurkumin"},
  {"id":"9b368af7-e255-5ae1-9403-154448676f4b","name":"E-101a Riboflavin-5-Phosphat"},
  {"id":"6c2a360c-45c3-5713-8eff-f2a7a6a99619","name":"E-101 Riboflavine"}
]

2. 2 characters
curl "http://localhost:8000/api/ingredients/autocomplete?query=ei&limit=3"

# Response:
[
  {"id":"f662257f-5e60-5eb9-896a-bef62d61d485","name":"Eier"},
  {"id":"f87d4091-a0c7-55a8-9a8d-fb8843d6b155","name":"Eierlikör"},
  {"id":"f7c05668-3c5a-575c-9c38-6d0a39bc723f","name":"Eierpastete"}
]

3. Test with a space

curl 'http://localhost:8000/api/ingredients/autocomplete?query=eier%20&limit=3'

[
  {"id":"e5e94a5b-f6de-54f3-a436-8496eda648dc","name":"Eier roh"}
]     

4. Test empty query

curl 'http://localhost:8000/api/ingredients/autocomplete?query=&limit=10' 