### PR TITLE
fix(auth): narrow internal auth bypass to agent-only via shared secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+# Shared secret for agent→backend internal auth bypass.
+# Only the agent service sends this header. Browser requests never do.
+# Change to a long random string in production.
+INTERNAL_SECRET=your-long-random-string-here
+
 # Database env
 POSTGRES_DB=recipe_db
 POSTGRES_USER=recipe_user

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Shared secret for agent→backend internal auth bypass.
 # Only the agent service sends this header. Browser requests never do.
-# Change to a long random string in production.
+# Change to a long random string in production. openssl rand -base64 32
 INTERNAL_SECRET=your-long-random-string-here
 
 # Database env

--- a/agent/app/agent.py
+++ b/agent/app/agent.py
@@ -53,9 +53,14 @@ os.environ["OPENAI_API_KEY"] = AGENT_API_KEY
 
 model = OpenAIModel(AGENT_MODEL)
 
+_INTERNAL_SECRET = os.getenv("INTERNAL_SECRET", "")
+
 def _backend_headers() -> dict[str, str]:
     """Return headers with forwarded auth from the frontend request."""
-    return get_auth_headers()
+    headers = get_auth_headers()
+    if _INTERNAL_SECRET:
+        headers["X-Internal-Secret"] = _INTERNAL_SECRET
+    return headers
 
 
 _http_client = httpx.AsyncClient()

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,11 +1,11 @@
 from typing import Annotated
-import ipaddress
 from uuid import UUID
 import jwt
 import os
 
 from fastapi import Depends, HTTPException, Request
 from sqlmodel import Session, select
+from fastapi.security import OAuth2PasswordBearer
 
 from .database import get_session
 from app.models import Users
@@ -21,27 +21,27 @@ SECRET_KEY = os.getenv("SECRET_KEY", "super_secret_key_for_testing")
 ALGORITHM = "HS256"
 DEFAULT_TENANT_ID = UUID(os.getenv("DEFAULT_TENANT_ID", "0b796544-6414-4d62-8f1f-cd2f9f0ac0a0"))
 
+# Security scheme for OpenAPI / Swagger UI.  auto_error=False so that cookie-based
+# auth still works at runtime, but the "Authorize" button is still rendered.
+_oauth2_optional = OAuth2PasswordBearer(tokenUrl="/api/auth/login", auto_error=False)
+INTERNAL_SECRET = os.getenv("INTERNAL_SECRET", "")
+
 # -----------------------------------------------------------------------------
-# Internal request detection (Docker network bypass)
+# Internal request detection (agent secret bypass)
 # -----------------------------------------------------------------------------
 
 def _is_internal_request(request: Request) -> bool:
-    """Return True if the request originates from the internal Docker network.
+    """Return True if the request carries the shared internal secret header.
 
     Used as a temporary bypass so the agent service can call backend
-    endpoints without forwarding auth headers. This is ONLY safe inside
-    a Docker-internal network where the agent cannot be reached from
-    outside. TODO: remove once proper auth forwarding is wired end-to-end.
+    endpoints without forwarding auth headers. Only the agent container
+    knows this secret. Browser-proxied requests through nginx never
+    carry this header, so normal cookie/auth flow still applies.
+    TODO: remove once proper auth forwarding is wired end-to-end.
     """
-    client = request.client
-    if client is None:
+    if not INTERNAL_SECRET:
         return False
-    host = client.host
-    try:
-        addr = ipaddress.ip_address(host)
-        return addr.is_loopback or addr.is_private
-    except ValueError:
-        return host in ("localhost", "backend", "agent")
+    return request.headers.get("X-Internal-Secret") == INTERNAL_SECRET
 
 
 # -----------------------------------------------------------------------------
@@ -51,6 +51,7 @@ def _is_internal_request(request: Request) -> bool:
 
 def get_current_user(
     request: Request,
+    _token: Annotated[str | None, Depends(_oauth2_optional)],
     session: Session = Depends(get_session),
 ) -> Users:
     """Decode the JWT from cookie or Authorization header and return the user."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       SQL_ECHO: ${SQL_ECHO}
       SECRET_KEY: ${SECRET_KEY}
       DEFAULT_TENANT_ID: ${DEFAULT_TENANT_ID}
+      INTERNAL_SECRET: ${INTERNAL_SECRET}
     volumes:
       # - ./backend/uploads:/code/uploads
       - uploads:/code/uploads
@@ -75,6 +76,7 @@ services:
       AGENT_API_KEY: ${AGENT_API_KEY}
       AGENT_MODEL: ${AGENT_MODEL:-deepseek-ai/deepseek-v4-flash}
       AGENT_DEBUG_STREAM: ${AGENT_DEBUG_STREAM}
+      INTERNAL_SECRET: ${INTERNAL_SECRET}
 
   stt:
     build:

--- a/frontend/kitchen/.env.example
+++ b/frontend/kitchen/.env.example
@@ -1,0 +1,4 @@
+# URL of the office frontend for auth redirects.
+# In dev mode, this should match the port office runs on (see office/vite.config.ts).
+# In Docker/production, this should be the nginx-exposed port.
+VITE_OFFICE_URL=http://localhost:5173

--- a/frontend/office/.env.example
+++ b/frontend/office/.env.example
@@ -1,0 +1,4 @@
+# URL of the kitchen frontend display.
+# In dev mode, this should match the port kitchen runs on.
+# In Docker/production, this should be the nginx-exposed port.
+VITE_KITCHEN_URL=http://localhost:8082

--- a/frontend/office/.env.example
+++ b/frontend/office/.env.example
@@ -1,4 +1,4 @@
 # URL of the kitchen frontend display.
 # In dev mode, this should match the port kitchen runs on.
 # In Docker/production, this should be the nginx-exposed port.
-VITE_KITCHEN_URL=http://localhost:8082
+VITE_KITCHEN_URL=http://localhost:5174

--- a/frontend/office/src/pages/StartingPage.tsx
+++ b/frontend/office/src/pages/StartingPage.tsx
@@ -15,7 +15,7 @@ export function StartingPage() {
         <p className="text-muted-foreground">What would you like to do today?</p>
       </div>
 
-      <div className="grid flex-1 gap-4 md:grid-cols-2">
+      <div className="grid flex-1 gap-4 md:grid-cols-3">
         <NavLink
           to="/recipes"
           className="group relative flex h-full min-h-0 flex-col items-center justify-center overflow-hidden rounded-lg border p-6 text-center transition-transform duration-300 ease-out hover:scale-[1.02]"
@@ -44,8 +44,10 @@ export function StartingPage() {
           <p className="mt-2 text-lg text-white/90">Plan your weekly menu.</p>
           </div>
         </NavLink>
-        <NavLink
-          to="/ai-assistant"
+        <a
+          href={KITCHEN_URL}
+          target="_blank"
+          rel="noopener noreferrer"
           className="group relative flex h-full min-h-0 flex-col items-center justify-center overflow-hidden rounded-lg border p-6 text-center transition-transform duration-300 ease-out hover:scale-[1.02]"
         >
           <div
@@ -54,22 +56,8 @@ export function StartingPage() {
           />
           <div className="pointer-events-none absolute inset-0 bg-black/35 opacity-100 transition-opacity duration-300 group-hover:opacity-100" />
           <div className="relative z-10">
-          <h2 className="text-3xl font-semibold text-white">AI Assistant</h2>
-          <p className="mt-2 text-lg text-white/90">Get help with ideas and prep.</p>
-          </div>
-        </NavLink>
-        <a
-          href={KITCHEN_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="group relative flex h-full min-h-0 flex-col items-center justify-center overflow-hidden rounded-lg border p-6 text-center transition-transform duration-300 ease-out hover:scale-[1.02]"
-        >
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-600 to-teal-800 transition-[filter] duration-300 ease-out" />
-          <div className="pointer-events-none absolute inset-0 bg-black/20 opacity-80 transition-opacity duration-300 group-hover:opacity-100" />
-          <div className="relative z-10 flex flex-col items-center">
-            <HugeiconsIcon icon={LayoutBottomIcon} strokeWidth={2} className="size-12 text-white/90 mb-3" />
-            <h2 className="text-3xl font-semibold text-white">Kitchen Display</h2>
-            <p className="mt-2 text-lg text-white/90">Open the kitchen screen.</p>
+          <h2 className="text-3xl font-semibold text-white">Ai Kitchen Display</h2>
+          <p className="mt-2 text-lg text-white/90">Open the kitchen screen.</p>
           </div>
         </a>
       </div>

--- a/frontend/office/src/pages/StartingPage.tsx
+++ b/frontend/office/src/pages/StartingPage.tsx
@@ -1,7 +1,11 @@
 import { NavLink } from "react-router-dom"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { LayoutBottomIcon } from "@hugeicons/core-free-icons"
 import recipeImage from "@/assets/voice-chef-recipe.jpg"
 import personImage from "@/assets/voice-chef-person.jpg"
 import aiImage from "@/assets/voice-chef-ai.jpg"
+
+const KITCHEN_URL = import.meta.env.VITE_KITCHEN_URL || "http://localhost:8082"
 
 export function StartingPage() {
   return (
@@ -11,7 +15,7 @@ export function StartingPage() {
         <p className="text-muted-foreground">What would you like to do today?</p>
       </div>
 
-      <div className="grid flex-1 gap-4 md:grid-cols-3">
+      <div className="grid flex-1 gap-4 md:grid-cols-2">
         <NavLink
           to="/recipes"
           className="group relative flex h-full min-h-0 flex-col items-center justify-center overflow-hidden rounded-lg border p-6 text-center transition-transform duration-300 ease-out hover:scale-[1.02]"
@@ -54,6 +58,20 @@ export function StartingPage() {
           <p className="mt-2 text-lg text-white/90">Get help with ideas and prep.</p>
           </div>
         </NavLink>
+        <a
+          href={KITCHEN_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group relative flex h-full min-h-0 flex-col items-center justify-center overflow-hidden rounded-lg border p-6 text-center transition-transform duration-300 ease-out hover:scale-[1.02]"
+        >
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-600 to-teal-800 transition-[filter] duration-300 ease-out" />
+          <div className="pointer-events-none absolute inset-0 bg-black/20 opacity-80 transition-opacity duration-300 group-hover:opacity-100" />
+          <div className="relative z-10 flex flex-col items-center">
+            <HugeiconsIcon icon={LayoutBottomIcon} strokeWidth={2} className="size-12 text-white/90 mb-3" />
+            <h2 className="text-3xl font-semibold text-white">Kitchen Display</h2>
+            <p className="mt-2 text-lg text-white/90">Open the kitchen screen.</p>
+          </div>
+        </a>
       </div>
     </div>
   );


### PR DESCRIPTION
Replaces the over-broad IP-based `_is_internal_request()` bypass with a shared secret header (`X-Internal-Secret`) that only the agent service sends.

**Problem:**
- The backend sees nginx container IPs (private Docker network) for ALL proxied browser requests
- Result: auth was bypassed for office → backend, kitchen → backend, and agent → backend

**Fix:**
- Backend checks for `X-Internal-Secret` header matching `INTERNAL_SECRET` env var
- Agent injects the header on every backend call
- Browser requests never carry this header, so normal cookie/auth flow applies

**Rollback:**
- Rotate `INTERNAL_SECRET` in `.env` and restart both services

**Future cleanup:**
- Remove once `@ag-ui/client` `HttpAgent` supports `credentials: "include"` and the agent can forward browser cookies
