### PR TITLE
User can add igredients on recipe creation

### DIFF
--- a/backend/app/api/routes/recipe.py
+++ b/backend/app/api/routes/recipe.py
@@ -13,7 +13,8 @@ from app.core.pagination import (
 from app.core.deps import get_current_user
 from app.utils.recipe_utils import (
     to_recipe_detail, to_recipe_summary, ensure_unique_recipe_name,
-    validate_recipe_business_rules
+    validate_recipe_business_rules, validate_all_ingredients_exist_no_duplicates,
+    validate_ingredient_sort_order
 )
 from app.utils.file_service_image_utils import delete_file
 from app.models.recipe import Recipe
@@ -21,7 +22,6 @@ from app.models.ingredient import Ingredient
 from app.models.recipe_ingredients import RecipeIngredient
 from app.models.users import Users
 from app.schemas.pagination import PaginatedResponse
-from app.schemas.ingredient import IngredientWrite
 from app.schemas.recipe import (
     RecipeWrite, RecipeSummaryResponse, RecipeUpdate, 
     RecipeDetailResponse, RecipeFilters, RecipeSort
@@ -123,22 +123,20 @@ def create_recipe(
 ):
     tenant_id = current_user.tenant_id
     ensure_unique_recipe_name(session, recipe.name, tenant_id)
-    
-    # Validate business rules (Error 400 from api-spec)
     validate_recipe_business_rules(recipe)
-    
-    payload = recipe.model_dump(exclude={"ingredients"})
-    payload["tenant_id"] = tenant_id
-    new_recipe = Recipe(**payload)
-    ingredients_data = recipe.ingredients or []
+    validate_ingredient_sort_order(recipe)
+    validate_all_ingredients_exist_no_duplicates(session, recipe)
 
     try:
-        # Create and save recipe first
+        payload = recipe.model_dump(exclude={"ingredients"})
+        payload["tenant_id"] = tenant_id
+        new_recipe = Recipe(**payload)
+        ingredients_data = recipe.ingredients or []
+
         session.add(new_recipe)
         session.flush()
         
         # Create ingredient links for each ingredient
-        # Loop through each ingredient
         for ing_data in ingredients_data:
             ingredient = session.get(Ingredient, ing_data.ingredient_id)
             if not ingredient:
@@ -160,9 +158,10 @@ def create_recipe(
             session.add(recipe_ingredient)
         
         session.commit()
-        session.refresh(new_recipe)
+        session.refresh(new_recipe, ["recipe_ingredients"])
         
         # Eagerly load ingredients for response
+        # This loads: Recipe → RecipeIngredient → Ingredient
         statement = (
             select(Recipe)
             .where(Recipe.id == new_recipe.id)
@@ -172,6 +171,8 @@ def create_recipe(
             )
         )
         new_recipe = session.exec(statement).first()
+
+        return to_recipe_detail(new_recipe)
         
     except IntegrityError as e:
         session.rollback()
@@ -193,8 +194,6 @@ def create_recipe(
             status_code=500, 
             detail="Internal server error"
         )
-
-    return to_recipe_detail(new_recipe)
 
 
 @router.patch("/{id}", response_model=RecipeSummaryResponse)

--- a/backend/app/schemas/recipe.py
+++ b/backend/app/schemas/recipe.py
@@ -10,8 +10,8 @@ from enum import Enum
 
 class RecipeIngredientWrite(SQLModel):
     ingredient_id: UUID
-    quantity: Decimal
-    unit: str
+    quantity: Decimal | None = None
+    unit: str | None = None
     preparation: str | None = None
     sort_order: int
 
@@ -40,8 +40,8 @@ class RecipeIngredientResponse(SQLModel):
     ingredient_name: str
     ingredient_default_unit: str
 
-    quantity: str
-    unit: str
+    quantity: str | None
+    unit: str | None
     quantity_grams: str
 
     preparation: str | None = None

--- a/backend/app/utils/recipe_utils.py
+++ b/backend/app/utils/recipe_utils.py
@@ -2,6 +2,7 @@ from sqlmodel import Session, select
 from uuid import UUID
 from fastapi import HTTPException, status
 from app.models.recipe import Recipe
+from app.models.ingredient import Ingredient
 
 
 def validate_recipe_business_rules(recipe) -> None:
@@ -54,7 +55,7 @@ def to_recipe_ingredient_response(link):
         "ingredient_name": ingredient.name,
         "ingredient_default_unit": ingredient.default_unit,
         "quantity": str(link.quantity) if link.quantity else None,
-        "unit": link.unit,
+        "unit": link.unit if link.unit else None,
         "quantity_grams": str(quantity_grams),
         "preparation": link.preparation.strip() if link.preparation else None,
         "sort_order": link.sort_order,
@@ -119,4 +120,93 @@ def ensure_unique_recipe_name(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT, 
             detail="Recipe name already exists"
+        )
+
+def validate_ingredient_sort_order(recipe) -> None:
+    """
+    Validate that sort_order values are sequential starting from 0 with no gaps.
+    
+    Expected sequence: 0, 1, 2, 3, ... (each value exactly +1 from previous)
+    
+    Raises:
+        HTTPException(409): If sort_order values are not sequential or have duplicates
+    """
+    if not recipe.ingredients:
+        return
+    
+    sort_orders = [ing.sort_order for ing in recipe.ingredients]
+    
+    # Check for duplicates
+    unique_sort_orders = set(sort_orders)
+    if len(sort_orders) != len(unique_sort_orders):
+        seen = set()
+        duplicates = set()
+        for sort_order in sort_orders:
+            if sort_order in seen:
+                duplicates.add(sort_order)
+            seen.add(sort_order)
+        
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Duplicate sort_order values found: {duplicates}"
+        )
+    
+    # Check for sequential order starting from 0
+    expected_sequence = set(range(len(sort_orders)))
+    actual_sequence = set(sort_orders)
+    
+    if actual_sequence != expected_sequence:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"sort_order must be sequential starting from 0. Expected: {sorted(expected_sequence)}, Got: {sorted(actual_sequence)}"
+        )
+
+
+def validate_all_ingredients_exist_no_duplicates(
+        session: Session,
+        recipe
+) -> None:
+    """
+    Validate that all ingredients exist in the database.
+    
+    Raises:
+        HTTPException(400): If any ingredient IDs don't exist in database
+        HTTPException(409): If there are duplicate ingredient_ids in the recipe
+    """
+    if not recipe.ingredients:
+        return
+    
+    # Check for duplicate ingredient_ids
+    ingredient_ids = []
+    for ing in recipe.ingredients:
+        ingredient_ids.append(ing.ingredient_id)
+    # Convert list to set: remove duplicates
+    unique_ids = set(ingredient_ids)
+    
+    if len(ingredient_ids) != len(unique_ids):
+        # Find duplicates
+        seen = set()
+        duplicates = set()
+        for ing_id in ingredient_ids:
+            if ing_id in seen:
+                duplicates.add(ing_id)
+            seen.add(ing_id)
+        
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Duplicate ingredient IDs found: {duplicates}"
+        )
+    
+    # Check that all ingredients exist in database
+    existing_ingredients = session.exec(
+        select(Ingredient).where(Ingredient.id.in_(unique_ids))
+    ).all()
+    
+    if len(existing_ingredients) != len(unique_ids):
+        # Check which id user sent that DB doesn't have
+        existing_ids = {ing.id for ing in existing_ingredients}
+        missing_ids = unique_ids - existing_ids
+        raise HTTPException(
+            status_code=400, 
+            detail=f"Invalid ingredient IDs: {missing_ids}"
         )

--- a/frontend/office/src/api/ingredients.ts
+++ b/frontend/office/src/api/ingredients.ts
@@ -1,0 +1,11 @@
+import { api } from './axios';
+import type { IngredientAutocompleteItem } from '@/types/ingredients';
+
+
+export const ingredientsAutocomplete = (query: string, limit: number = 10) =>
+  api.get<IngredientAutocompleteItem[]>('/ingredients/autocomplete', {
+    params: {
+      query,
+      limit,
+    },
+  });

--- a/frontend/office/src/api/recipes.ts
+++ b/frontend/office/src/api/recipes.ts
@@ -1,20 +1,24 @@
 // This file defines API helper functions that wrap the Axios instance and add type safety + convenience.
 
 import { api } from './axios';
-import type { PaginatedResponse, Recipe, RecipeWrite } from '@/types/recipe';
+import type {
+  PaginatedResponse, 
+  RecipeSummary,
+  RecipeDetail, 
+  RecipeWrite } from '@/types/recipe';
 
 export const getRecipes = (params?: { status?: string; offset?: number; limit?: number }) =>
-  api.get<PaginatedResponse<Recipe>>('/recipes', { params });
+  api.get<PaginatedResponse<RecipeSummary>>('/recipes', { params });
 
 export const getRecipe = (id: string) => 
-  api.get<Recipe>(`/recipes/${id}`);
+  api.get<RecipeDetail>(`/recipes/${id}`);
 
 export const createRecipe = (recipe: RecipeWrite) => 
-  api.post<Recipe>('/recipes', recipe);
+  api.post<RecipeDetail>('/recipes', recipe);
 
 // TO DO: mpeshko
-// export const updateRecipe = (id: string, updates: Partial<Recipe>) => 
-//   api.patch<Recipe>(`/recipes/${id}`, updates);
+export const updateRecipe = (id: string, updates: Partial<RecipeDetail>) => 
+  api.patch<RecipeDetail>(`/recipes/${id}`, updates);
 
 export const deleteRecipe = (id: string) => 
-  api.delete<Recipe>(`/recipes/${id}`);
+  api.delete<void>(`/recipes/${id}`);

--- a/frontend/office/src/components/recipes/InlineEditableRecipeText.tsx
+++ b/frontend/office/src/components/recipes/InlineEditableRecipeText.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 import { useUpdateRecipe } from '@/hooks/useRecipes';
-import type { Recipe } from '@/types/recipe';
+import type { RecipeDetail } from '@/types/recipe';
 
 type EditableRecipeField = 'name' | 'description' | 'instructions';
 
@@ -49,12 +49,10 @@ export function InlineEditableRecipeText({
 
     const payload =
       field === 'name'
-        ? ({ id: recipeId, name: nextValue } as Partial<Recipe> & { id: string })
-        : ({ id: recipeId, [field]: nextValue || null } as Partial<Recipe> & { id: string });
+        ? ({ id: recipeId, name: nextValue } as Partial<RecipeDetail> & { id: string })
+        : ({ id: recipeId, [field]: nextValue || null } as Partial<RecipeDetail> & { id: string });
 
-    updateRecipe.mutate(
-      payload,
-      {
+    updateRecipe.mutate(payload, {
         onSuccess: () => {
           setValidationError(null);
           setIsEditing(false);
@@ -96,7 +94,11 @@ export function InlineEditableRecipeText({
             <p className="text-xs text-destructive">{validationError}</p>
           )}
           <div className="flex gap-2">
-            <Button size="sm" type="button" onClick={handleSave} disabled={updateRecipe.isPending}>
+            <Button 
+              size="sm" 
+              type="button" 
+              onClick={handleSave} 
+              disabled={updateRecipe.isPending}>
               Save
             </Button>
             <Button

--- a/frontend/office/src/components/recipes/RecipeCard.tsx
+++ b/frontend/office/src/components/recipes/RecipeCard.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { cn } from '@/lib/utils';
-import type { Recipe } from '@/types/recipe';
+import type { RecipeSummary } from '@/types/recipe';
 
 const RECIPE_CARD_TITLE_MAX_LENGTH = 64;
 
@@ -20,7 +20,7 @@ const STATUS_STYLES: Record<string, string> = {
 
 
 interface RecipeCardProps {
-  recipe: Recipe;
+  recipe: RecipeSummary;
 }
 
 export function RecipeCard({ recipe }: RecipeCardProps) {

--- a/frontend/office/src/components/ui/combobox.tsx
+++ b/frontend/office/src/components/ui/combobox.tsx
@@ -1,0 +1,99 @@
+import * as React from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+export interface ComboboxOption {
+  value: string
+  label: string
+}
+
+interface ComboboxProps {
+  options: ComboboxOption[]
+  value?: string
+  onValueChange?: (value: string) => void
+  placeholder?: string
+  searchPlaceholder?: string
+  emptyText?: string
+  isLoading?: boolean
+  onSearchChange?: (search: string) => void
+}
+
+export function Combobox({
+  options,
+  value,
+  onValueChange,
+  placeholder = "Select option...",
+  searchPlaceholder = "Search...",
+  emptyText = "No options found.",
+  isLoading = false,
+  onSearchChange,
+}: ComboboxProps) {
+  const [open, setOpen] = React.useState(false)
+  const [search, setSearch] = React.useState("")
+
+  const selectedLabel = options.find((opt) => opt.value === value)?.label || placeholder
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newSearch = e.target.value
+    setSearch(newSearch)
+    onSearchChange?.(newSearch)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            "w-full justify-start h-9 border-black",
+            !value && "text-muted-foreground"
+          )}
+        >
+          <span className="truncate">{selectedLabel}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-full p-2" align="start">
+        <div className="space-y-2 w-full">
+          <Input
+            placeholder={searchPlaceholder}
+            value={search}
+            onChange={handleSearchChange}
+            className="h-8 w-full"
+          />
+          <div className="max-h-48 overflow-y-auto">
+            {isLoading && (
+              <div className="p-2 text-sm text-muted-foreground">Loading...</div>
+            )}
+            {!isLoading && options.length === 0 && (
+              <div className="p-2 text-sm text-muted-foreground">{emptyText}</div>
+            )}
+            {!isLoading && options.length > 0 && (
+              <ul>
+                {options.map((option) => (
+                  <li
+                    key={option.value}
+                    onClick={() => {
+                      onValueChange?.(option.value)
+                      setOpen(false)
+                      setSearch("")
+                    }}
+                    className="px-3 py-2 hover:bg-accent cursor-pointer text-sm rounded"
+                  >
+                    {option.label}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/office/src/hooks/useIngredients.ts
+++ b/frontend/office/src/hooks/useIngredients.ts
@@ -1,8 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/api/axios';
+import { ingredientsAutocomplete } from '@/api/ingredients';
 import type { Ingredient, PaginatedResponse } from '@/types/recipe';
 
 const INGREDIENTS_KEY = 'ingredients';
+const INGREDIENTS_AUTOCOMPLETE_KEY = 'ingredients-autocomplete';
 
 export function useIngredients(filters?: {
   search?: string;
@@ -18,5 +20,16 @@ export function useIngredients(filters?: {
       });
       return data;
     },
+  });
+}
+
+export function useIngredientsAutocomplete(query: string, limit: number = 10) {
+  return useQuery({
+    queryKey: [INGREDIENTS_AUTOCOMPLETE_KEY, query, limit],
+    queryFn: async () => {
+      const { data } = await ingredientsAutocomplete(query, limit);
+      return data;
+    },
+    enabled: query.length >= 2,
   });
 }

--- a/frontend/office/src/hooks/useRecipes.ts
+++ b/frontend/office/src/hooks/useRecipes.ts
@@ -4,14 +4,17 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import { api } from '@/api/axios';
 import { 
   getRecipes, 
   getRecipe, 
-  createRecipe, 
+  createRecipe,
+  updateRecipe,
   deleteRecipe } from '@/api/recipes';
 import { uploadRecipePhoto, deleteRecipePhoto } from '@/api/recipePhotos';
-import type { Recipe, RecipeWrite } from '@/types/recipe';
+import type { 
+  RecipeSummary,
+  RecipeDetail, 
+  RecipeWrite } from '@/types/recipe';
 
 const RECIPES_KEY = 'recipe';
 
@@ -38,7 +41,7 @@ export function useAllRecipes(pageSize = 100) {
     queryKey: [RECIPES_KEY, 'all', pageSize],
     queryFn: async () => {
       const safePageSize = Math.min(Math.max(pageSize, 1), 100);
-      const allRecipes: Recipe[] = [];
+      const allRecipes: RecipeSummary[] = [];
       let offset = 0;
       let total = 0;
 
@@ -59,14 +62,19 @@ export function useAllRecipes(pageSize = 100) {
   });
 }
 
-export function useRecipe(id: string) {
+// The enabled flag is used here to provide granular control over when 
+// the network request should fire.
+// External Control: This is particularly useful during a deletion process: 
+// once a recipe is deleted, you can set enabled to false to prevent TanStack Query 
+// from automatically refetching a resource that no longer exists in the database.
+export function useRecipe(id: string, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: [RECIPES_KEY, id],
     queryFn: async () => {
       const { data } = await getRecipe(id);
       return data;
     },
-    enabled: !!id,
+    enabled: !!id && (options?.enabled ?? true),
     retry: (failureCount, error: any) => {
       // Don't retry if it's a 401; the interceptor is handling it
       if (error.response?.status === 401) return false;
@@ -91,8 +99,10 @@ export function useCreateRecipe() {
 export function useUpdateRecipe() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ id, ...updates }: Partial<Recipe> & { id: string }) => {
-      const { data } = await api.patch<Recipe>(`/recipes/${id}`, updates);
+    mutationFn: async ({ id, ...updates }: Partial<RecipeDetail> & { id: string }) => {
+      //                 ↑ Destructuring: extract id separately
+      //                      ↑ Rest of the fields (name, description, instructions, etc.)
+      const { data } = await updateRecipe(id, updates);
       return data;
     },
     onSuccess: (updatedRecipe) => {
@@ -112,9 +122,9 @@ export function useDeleteRecipe() {
       const { data } = await deleteRecipe(id);
       return data;
     },
-    onSuccess: (deletedRecipe) => {
-      queryClient.removeQueries({ queryKey: [RECIPES_KEY, deletedRecipe.id] });
-      queryClient.invalidateQueries({ queryKey: [RECIPES_KEY] });
+    onSuccess: (_data, id) => { // The first argument is empty (_)
+      queryClient.removeQueries({ queryKey: [RECIPES_KEY, id] });
+      queryClient.invalidateQueries({ queryKey: [RECIPES_KEY], exact: true});
     },
   });
 }

--- a/frontend/office/src/pages/CreateRecipePage.tsx
+++ b/frontend/office/src/pages/CreateRecipePage.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useCreateRecipe } from '@/hooks/useRecipes';
+import { useIngredientsAutocomplete } from '@/hooks/useIngredients';
+import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Section } from '@/components/Section';
@@ -19,6 +21,21 @@ export function CreateRecipePage() {
 
   const [name, setName] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  // creating `ingredients` variable that will change, 
+  // and the `setIngredients` function to update it
+  const [ingredients, setIngredients] = useState<Array<{ 
+    id: string; 
+    ingredientId: string | null; 
+    name: string; 
+    quantity: string | null 
+  }>>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  // useIngredientsAutocomplete
+  const { 
+    data: autocompleteResults = [], 
+    isLoading: isLoadingAutocomplete 
+  } = useIngredientsAutocomplete(searchQuery);
   const draftStatus = 'draft';
 
   const handleSave = () => {
@@ -29,7 +46,23 @@ export function CreateRecipePage() {
       return;
     }
     setError(null);
-    createRecipe.mutate({name: trimmedName, status: 'draft',},
+
+    // Filter out ingredients without an ingredientId
+    const validIngredients = ingredients
+      .filter(ingredient => ingredient.ingredientId !== null)
+      .map((ingredient, index) => ({
+        ingredient_id: ingredient.ingredientId!,
+        quantity: ingredient.quantity || undefined,
+        unit: 'g',
+        sort_order: index,
+      }));
+
+    createRecipe.mutate(
+      {
+        name: trimmedName,
+        status: 'draft',
+        ingredients: validIngredients,
+      },
       {
         onSuccess: (recipe) => {
           navigate(`/recipes/${recipe.id}`);
@@ -37,6 +70,34 @@ export function CreateRecipePage() {
       },
     );
   };
+
+  const addIngredientRow = () => {
+    const newId = Date.now().toString();
+    setIngredients([
+      ...ingredients, { 
+        id: newId, 
+        ingredientId: null, 
+        name: '', 
+        quantity: null }
+      ]);
+  };
+
+  const removeIngredientRow = (id: string) => {
+    setIngredients(ingredients.filter(ingredient => ingredient.id !== id));
+  };
+
+  const selectIngredient = (id: string, ingredientId: string, ingredientName: string) => {
+    setIngredients(ingredients.map(ingredient =>
+      ingredient.id === id ? { ...ingredient, ingredientId, name: ingredientName } : ingredient
+    ));
+    setSearchQuery('');
+  };
+
+  // Convert autocomplete results to combobox options
+  const comboboxOptions: ComboboxOption[] = autocompleteResults.map(result => ({
+    value: result.id,
+    label: result.name,
+  }));
 
   const badgeClass = cn(
     'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize',
@@ -101,7 +162,61 @@ export function CreateRecipePage() {
         {/* Right column - Ingredients */}
         <div className="lg:col-span-8">
           <Section title="Ingredients">
-            <p className="text-sm text-muted-foreground italic">Ingredients input coming soon.</p>
+            <div className="space-y-3">
+              {ingredients.map((ingredient) => (
+                <div key={ingredient.id} className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1">
+                      <Combobox
+                        options={comboboxOptions}
+                        value={ingredient.ingredientId || ''}
+                        onValueChange={(value) => {
+                          const selected = autocompleteResults.find(r => r.id === value);
+                          if (selected) {
+                            selectIngredient(ingredient.id, selected.id, selected.name);
+                          }
+                        }}
+                        onSearchChange={setSearchQuery}
+                        placeholder={ingredient.name || 'Click here to search'}
+                        searchPlaceholder="Type to search..."
+                        emptyText="No ingredients found."
+                        isLoading={isLoadingAutocomplete}
+                      />
+                    </div>
+                    <Input
+                      type="number"
+                      value={ingredient.quantity || ''}
+                      onChange={(e) => {
+                        setIngredients(ingredients.map(ing =>
+                          ing.id === ingredient.id ? { ...ing, quantity: e.target.value || null } : ing
+                        ));
+                      }}
+                      placeholder="Qty"
+                      className="w-24"
+                    />
+                    <span className="text-sm font-medium text-gray-700 w-6">g</span>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => removeIngredientRow(ingredient.id)}
+                      className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                    >
+                      ✕
+                    </Button>
+                  </div>
+                  {ingredient.ingredientId && (
+                    <p className="text-xs text-muted-foreground">ID: {ingredient.ingredientId}</p>
+                  )}
+                </div>
+              ))}
+              <Button
+                variant="outline"
+                onClick={addIngredientRow}
+                className="border-black text-lg text-green-900 font-bold px-3 py-1 h-auto"
+              >
+                + Add Row
+              </Button>
+            </div>
           </Section>
         </div>
       </div>

--- a/frontend/office/src/pages/CreateRecipePage.tsx
+++ b/frontend/office/src/pages/CreateRecipePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useCreateRecipe } from '@/hooks/useRecipes';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Section } from '@/components/Section';
 import { cn } from '@/lib/utils';
 
 const STATUS_STYLES: Record<string, string> = {
@@ -27,13 +28,8 @@ export function CreateRecipePage() {
       setError('Recipe name is required.');
       return;
     }
-
     setError(null);
-
-    createRecipe.mutate(
-      {
-        name: trimmedName, status: 'draft',
-      },
+    createRecipe.mutate({name: trimmedName, status: 'draft',},
       {
         onSuccess: (recipe) => {
           navigate(`/recipes/${recipe.id}`);
@@ -49,40 +45,64 @@ export function CreateRecipePage() {
 
   return (
     <div className="space-y-5 max-w-10xl">
-      <div className="space-y-4">
-        <Button size="sm" onClick={() => navigate(-1)}>← Back</Button>
-
-        <div className="flex items-center gap-3 flex-wrap mt-6">
-          <div className="space-y-1 w-full sm:w-auto sm:min-w-[28rem]">
-            <Input
-              id="recipe-name"
-              value={name}
-              onChange={(event) => {
-                setName(event.target.value);
-                if (error) {
-                  setError(null);
-                }
-              }}
-              placeholder="Untitled recipe"
-              className="h-12 text-2xl font-semibold"
-              autoFocus
-            />
-            {error && <p className="text-xs text-destructive">{error}</p>}
-          </div>
-          <span className={badgeClass}>{draftStatus}</span>
-        </div>
-
-        <div className="flex flex-wrap gap-3">
+      {/* Header Section */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Create New Recipe</h1>
+        <div className="flex items-center gap-2">
+          <Button
+            size="lg"
+            variant="outline"
+            onClick={() => navigate('/recipes/')}
+            className="text-gray-600"
+          >
+            Cancel
+          </Button>
           <Button
             size="lg"
             type="button"
-            className="min-w-40"
             onClick={handleSave}
             disabled={createRecipe.isPending}
             aria-busy={createRecipe.isPending}
           >
-            {createRecipe.isPending ? 'Saving...' : 'Save recipe name & Proceed to details'}
+            {createRecipe.isPending ? 'Saving...' : 'Save'}
           </Button>
+        </div>
+      </div>
+
+      {/* Content Section - Two Columns */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 items-start">
+        {/* Left column - Basic Info */}
+        <div className="lg:col-span-4">
+          <Section title="Basic Info">
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <Input
+                  id="recipe-name"
+                  value={name}
+                  onChange={(event) => {
+                    setName(event.target.value);
+                    if (error) {
+                      setError(null);
+                    }
+                  }}
+                  placeholder="Untitled recipe"
+                  className="h-12 text-lg font-semibold"
+                  autoFocus
+                />
+                {error && <p className="text-xs text-destructive">{error}</p>}
+              </div>
+              <div className="flex items-center">
+                <span className={badgeClass}>{draftStatus}</span>
+              </div>
+            </div>
+          </Section>
+        </div>
+
+        {/* Right column - Ingredients */}
+        <div className="lg:col-span-8">
+          <Section title="Ingredients">
+            <p className="text-sm text-muted-foreground italic">Ingredients input coming soon.</p>
+          </Section>
         </div>
       </div>
     </div>

--- a/frontend/office/src/pages/RecipeDetailPage.tsx
+++ b/frontend/office/src/pages/RecipeDetailPage.tsx
@@ -1,5 +1,10 @@
 import { useParams, useNavigate } from 'react-router-dom';
-import { useDeleteRecipe, useRecipe, useUpdateRecipe, useUploadRecipePhoto, useDeleteRecipePhoto } from '@/hooks/useRecipes';
+import { 
+  useDeleteRecipe, 
+  useRecipe, 
+  useUpdateRecipe, 
+  useUploadRecipePhoto, 
+  useDeleteRecipePhoto } from '@/hooks/useRecipes';
 import { Button } from '@/components/ui/button';
 import { InlineEditableRecipeText } from '../components/recipes/InlineEditableRecipeText';
 import { Section } from '../components/Section';
@@ -16,38 +21,23 @@ const STATUS_STYLES: Record<string, string> = {
 };
 
 
-// function TextBlock({ label, value }: { label: string; value: string | null | undefined }) {
-//   return (
-//     <div className="space-y-1">
-//       {label && <span className="text-xs text-muted-foreground uppercase tracking-wide">{label}</span>}
-//       {value
-//         ? <p className="text-sm leading-relaxed whitespace-pre-line">{value}</p>
-//         : <p className="text-sm text-muted-foreground/50 italic">empty</p>
-//       }
-//     </div>
-//   );
-// }
-
-// function formatDate(value: string | null | undefined) {
-//   if (!value) return null;
-//   return new Date(value).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
-// }
-
-
 export function RecipeDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { data: recipe, isLoading, isError } = useRecipe(id!);
-  const moveToActive = useUpdateRecipe();
   const deleteRecipe = useDeleteRecipe();
+  // TanStack Query is very sensitive to the enabled flag. As soon as you click 
+  // the "Delete" button and the backend returns 204, the deleteMutation.isSuccess 
+  // status instantly becomes true.
+  const { data: recipe, isLoading, isError } = useRecipe(id!, {
+    enabled: !deleteRecipe.isSuccess
+  });
+  const moveToActive = useUpdateRecipe();
   const uploadPhoto = useUploadRecipePhoto();
   const deletePhoto = useDeleteRecipePhoto();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleMoveToActive = () => {
-    if (!recipe) {
-      return;
-    }
+    if (!recipe) { return; }
 
     moveToActive.mutate({
       id: recipe.id,
@@ -56,17 +46,13 @@ export function RecipeDetailPage() {
   };
 
   const handleDeleteRecipe = () => {
-    if (!recipe) {
-      return;
-    }
+    if (!recipe) return;
 
     const confirmed = window.confirm(
       `Delete recipe "${recipe.name}"? This cannot be undone.`,
     );
 
-    if (!confirmed) {
-      return;
-    }
+    if (!confirmed) return;
 
     deleteRecipe.mutate(recipe.id, {
       onSuccess: () => {
@@ -91,14 +77,10 @@ export function RecipeDetailPage() {
   };
 
   const handleDeletePhoto = () => {
-    if (!recipe?.photo_url) {
-      return;
-    }
+    if (!recipe?.photo_url) { return; }
 
     const confirmed = window.confirm('Delete this recipe picture?');
-    if (!confirmed) {
-      return;
-    }
+    if (!confirmed) { return; }
 
     deletePhoto.mutate(recipe.id);
   };

--- a/frontend/office/src/pages/RecipeDetailPage.tsx
+++ b/frontend/office/src/pages/RecipeDetailPage.tsx
@@ -1,4 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { 
   useDeleteRecipe, 
   useRecipe, 
@@ -24,6 +26,7 @@ const STATUS_STYLES: Record<string, string> = {
 export function RecipeDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const deleteRecipe = useDeleteRecipe();
   // TanStack Query is very sensitive to the enabled flag. As soon as you click 
   // the "Delete" button and the backend returns 204, the deleteMutation.isSuccess 
@@ -35,6 +38,16 @@ export function RecipeDetailPage() {
   const uploadPhoto = useUploadRecipePhoto();
   const deletePhoto = useDeleteRecipePhoto();
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Navigate away immediately after successful deletion
+  useEffect(() => {
+    if (deleteRecipe.isSuccess) {
+      // Remove the recipe from cache immediately to prevent "not found" error
+      queryClient.removeQueries({ queryKey: ['recipe', id] });
+      // Navigate away
+      navigate('/recipes');
+    }
+  }, [deleteRecipe.isSuccess, navigate, queryClient, id]);
 
   const handleMoveToActive = () => {
     if (!recipe) { return; }
@@ -54,11 +67,7 @@ export function RecipeDetailPage() {
 
     if (!confirmed) return;
 
-    deleteRecipe.mutate(recipe.id, {
-      onSuccess: () => {
-        navigate('/recipes');
-      },
-    });
+    deleteRecipe.mutate(recipe.id);
   };
 
   const handlePhotoClick = () => {
@@ -96,7 +105,8 @@ export function RecipeDetailPage() {
     );
   }
 
-  if (isError || !recipe) {
+  // Show error only if recipe genuinely doesn't exist (not during deletion)
+  if (isError && !deleteRecipe.isPending && !deleteRecipe.isSuccess) {
     return (
       <div className="space-y-4">
         <Button variant="outline" onClick={() => navigate('/recipes')}>← Back to recipes</Button>
@@ -105,6 +115,11 @@ export function RecipeDetailPage() {
         </div>
       </div>
     );
+  }
+
+  // If recipe data is missing but we're not in an error state, don't render
+  if (!recipe) {
+    return null;
   }
 
   const badgeClass = cn(

--- a/frontend/office/src/types/ingredients.ts
+++ b/frontend/office/src/types/ingredients.ts
@@ -1,0 +1,4 @@
+export interface IngredientAutocompleteItem {
+  id: string;
+  name: string;
+}

--- a/frontend/office/src/types/recipe.ts
+++ b/frontend/office/src/types/recipe.ts
@@ -54,9 +54,9 @@ export interface PaginatedResponse<T> {
 
 export interface RecipeIngredientWrite {
   ingredient_id: string;
-  quantity: string;
-  unit: string;
-  preparation: string | null;
+  quantity?: string | null;
+  unit?: string | null;
+  preparation?: string | null;
   sort_order: number;
 }
 

--- a/frontend/office/src/types/recipe.ts
+++ b/frontend/office/src/types/recipe.ts
@@ -11,8 +11,7 @@ export interface RecipeIngredientResponse {
   sort_order: number;
 }
 
-export interface Recipe {
-  // RecipeSummary
+export interface RecipeSummary { // old Recipe
   id: string;
   name: string;
   description: string | null;
@@ -25,14 +24,15 @@ export interface Recipe {
   photo_url: string | null;
   created_at: string;
   updated_at: string;
-  
-  // export interface RecipeDetail extends RecipeSummary
+}
+
+export interface RecipeDetail extends RecipeSummary {
   instructions: string | null;
   preparation_time_minutes: number | null;
   cooking_time_minutes: number | null;
   is_component: boolean;
   ingredients?: RecipeIngredientResponse[];
-  
+
   // below: present in DB Shema, but not used
   // created_by: string | null;
   // yield_amount: number | null;
@@ -41,6 +41,7 @@ export interface Recipe {
   // recipe_number: string | null;
   // storage_temperature: string | null;
 }
+  
 
 export interface PaginatedResponse<T> {
   items: T[];


### PR DESCRIPTION
## HOW TO TEST

1. Open the office frontend and log in.
2. On the sidebar, click on "Recipes".
3. Click on the button "Create a new recipe" (it's up and right).
4. Create a recipe with ingredients and quantities in grams.
5. Notice the new frontend ui component "Combobox" - a pop-up search window, and there are up to 10 ingredients from the DB.

<img width="1578" height="769" alt="image" src="https://github.com/user-attachments/assets/d20bf6f9-1c0e-4f61-ba9d-7d6edd86d7a3" />



---
6. [Fixed bug] Delete any recipe. Check that you don't see the "Recipe not found" message on deletion.

## Technical comments

**1. fix-bug:** after deleting a recipe, the next request was GET this recipe with an obvious 404.

  - Fixed in the frontend/office/src/hooks/useRecipes.ts and frontend/office/src/pages/RecipeDetailPage.tsx
  - The enabled flag is used here to provide granular control over when the network request should be made. This is particularly useful during a deletion process: once a recipe is deleted, you can set enabled to false to prevent TanStack Query from automatically refetching a resource that no longer exists in the database.
 
**2. fix-bug:** after we clicked "Delete" a recipe, for a moment on the screen, there was a "Recipe not found" message.

- It is fixed in file office/src/pages/RecipeDetailPage.tsx. With the useEffect React hook, useQueryClient TanStack Query hook, and some additional conditions for the "isError" statement.

**3.  [backend]** POST /recipes/ fix bugs + more validation

