### PR TITLE
[docker] nginx-proxy doesn't run in dev mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,8 @@ AGENT_API_KEY=
 # OPENROUTER_API_KEY=
 # OPENAI_API_KEY=
 
+AGENT_DEBUG_STREAM=0
+
 # Nginx proxy / SSL
 # Domain name or IP address used in the self-signed certificate's CN and SAN.
 # Default is localhost.

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ $(ENV):
 	@test -f $(ENV) || (cp .env.example $(ENV) && echo "Created $(ENV) from .env.example")
 
 # ── Development targets ────────────────────────────────────────────────────
+
 # Use these when working locally. They mount source code as volumes for
 # hot-reload and bind service ports directly to the host.
 #
@@ -37,6 +38,12 @@ $(ENV):
 #   make dev-back         Start only db + backend (for API-only work)
 #   make dev-back-office  Start db + backend + office-frontend
 #   make up               Start existing containers (no rebuild, fastest)
+
+# Dev mode access:
+# - Office: http://localhost:5173
+# - Kitchen: http://localhost:5174
+# - Backend API: http://localhost:8000
+
 dev: $(ENV)
 	@echo "Building and starting in dev_mode (cached)"
 	$(COMPOSE) -f $(PROD_FILE) -f $(DEV_FILE) up --build
@@ -54,7 +61,9 @@ dev-back: $(ENV)
 dev-back-office: $(ENV)
 	@echo "Building and running db, backend and office-frontend services in dev_mode"
 	$(COMPOSE) -f $(PROD_FILE) -f $(DEV_FILE) up -d --build db backend office-frontend
+
 # ── Production target ──────────────────────────────────────────────────────
+
 # Use this for VPS / CI-CD deployments. Builds all images from scratch
 # (--no-cache) then recreates containers with zero-downtime rolling.
 #

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,7 @@
 services:
+  nginx-proxy:
+    profiles: ["disabled"]  # Keeps it in compose but won't start
+
   office-frontend:
     build:
       target: dev


### PR DESCRIPTION
It's a bug-fix PR.

When we run `make dev` and `make dev-re` there is no error message about port 80. 

---

However, it is still a problem for `make prod` - issues #227 