### PR TITLE
[fix] login form displays Invalid email or password

### DIFF
--- a/frontend/office/src/api/axios.ts
+++ b/frontend/office/src/api/axios.ts
@@ -31,11 +31,16 @@ api.interceptors.response.use(
   },
   (error) => {
     if (error.response && error.response.status === 401) {
-      console.warn("Unauthorized! Redirecting to login...");
+      // Don't redirect if we're already on the login page
+      // (allows login form to show the "Invalid email or password" error)
+      const isLoginPage = window.location.pathname === "/login" || window.location.pathname === "/signup";
       
-      localStorage.removeItem("token");
-
-      window.location.href = "/login";
+      if (!isLoginPage) {
+        console.warn("Unauthorized! Redirecting to login...");
+        localStorage.removeItem("token");
+        localStorage.removeItem("user");
+        window.location.href = "/login";
+      }
     }
 
     // Still reject the promise so the calling component can handle local errors


### PR DESCRIPTION
## How to test

1. Open `http://localhost:5173/login`
2. Try to log in with invalid credentials
3. You should see red message "Invalid email or password"
