### PR TITLE
fix: VITE_KITCHEN_URL default and clean-nginx in Makefile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,9 +56,10 @@ DOMAIN_NAME=localhost
 
 # Frontend env
 # URL for the kitchen display link in office frontend.
-# In production behind shared proxy: https://<host>/kitchen/
-# In local dev: http://localhost:5174 (docker-compose.override handles this)
-VITE_KITCHEN_URL=http://localhost:8082
+# Production (make prod):  /kitchen/ (accessed via nginx-proxy)
+# Dev (make dev): Overridden to http://localhost:5174 in docker-compose.override.yml
+# This value is only used in production; dev mode ignores it.
+VITE_KITCHEN_URL=/kitchen/
 
 # STT (Speech-to-Text) env
 STT_MODEL=base

--- a/Makefile
+++ b/Makefile
@@ -104,13 +104,21 @@ stop:
 	$(COMPOSE) -f $(PROD_FILE) -f $(DEV_FILE) stop
 
 # ── Clean-up targets ───────────────────────────────────────────────────────
-#   make clean    Remove containers + images (keeps volumes & data)
-#   make fclean   NUCLEAR OPTION: removes everything including volumes
-#                 (WARNING: this wipes the database and uploaded files)
+#   make clean       Remove containers + images (keeps volumes & data)
+#   make clean-nginx Remove ALL images including nginx (keeps database volume)
+#   make fclean      NUCLEAR OPTION: removes everything including volumes
+#                    (WARNING: this wipes the database and uploaded files)
 
 clean:
 	@echo "Stopping the app and removing containers + images..."
 	$(COMPOSE) down --rmi local
+
+clean-nginx:
+	@echo "Removing ALL Docker images (including nginx-proxy)..."
+	$(COMPOSE) down --rmi all --remove-orphans
+	$(COMPOSE) rm -f nginx-proxy
+	docker rmi voice-chef-nginx-proxy:latest
+	@echo "All images removed. Database volume preserved."
 
 fclean:
 	@echo "Stopping the app and removing containers + images + volumes..."
@@ -222,6 +230,7 @@ help:
 	@printf "     %-30s %s\n" "make down"        "Stop and remove containers"
 	@printf "     %-30s %s\n" "make stop"        "Stop containers (keep them)"
 	@printf "     %-30s %s\n" "make clean"       "Remove containers + images (keeps data)"
+	@printf "     %-30s %s\n" "make clean-nginx" "Remove ALL images including nginx (keeps DB)"
 	@printf "     %-30s %s\n" "make fclean"      "⚠️  NUCLEAR: removes everything including DB + uploads"
 	@printf "\n  🔧  PER-SERVICE REBUILDS\n"
 	@printf "     %-30s %s\n" "make agent-build-nocache"  "Rebuild agent from scratch"
@@ -241,6 +250,6 @@ help:
 # Catch-all for unrecognized targets.
 %:
 	@echo "Unknown target '$@'. Run 'make help' for available commands."
-.PHONY: all dev dev-re dev-back dev-back-office prod down re clean fclean status logs help build up start stop
+.PHONY: all dev dev-re dev-back dev-back-office prod down re clean clean-nginx fclean status logs help build up start stop
 .PHONY: agent-build agent-build-nocache agent-recreate stt-build stt-build-nocache stt-recreate
 .PHONY: refresh-env-agent dump-blast-check dump-regen drift-gate-local db-connect agent-terminal

--- a/frontend/kitchen/.env.example
+++ b/frontend/kitchen/.env.example
@@ -1,5 +1,0 @@
-# URL of the office frontend for auth redirects.
-# In dev mode: http://localhost:5173 (set in docker-compose.override.yml)
-# In production: leave empty — shared proxy serves both frontends on the same origin,
-#   so the kitchen redirects to /login (same-origin).
-VITE_OFFICE_URL=http://localhost:5173

--- a/frontend/office/.env.example
+++ b/frontend/office/.env.example
@@ -1,4 +1,0 @@
-# URL of the kitchen frontend display.
-# In dev mode, this should match the port kitchen runs on.
-# In Docker/production, this should be the nginx-exposed port.
-VITE_KITCHEN_URL=http://localhost:5174


### PR DESCRIPTION
## DONE

1. Updated VITE_KITCHEN_URL default value for production
2. Add clean-nginx target in Makefile
3. Cleanup: Frontend level `.env`'s are deleted.

---

### How to test

### DEV MODE
1. run `make dev`
Every services should work as expected:

- [ ] Office: http://localhost:5173
- [ ] Kitchen: http://localhost:5174

2. run `make clean-nginx`

- [ ] It should stop all container and remove nginx image

Note: `make clean` doesn't stop nginx container and doesn't remove nginx image.

4. run `make prod`
Every services should work as expected.

Note: on 42 PC I changed nginx port to 4444:444 in docker-compose to make it work. 

---

## DETAILS

### Frontend level: .env

We had .env files at two levels before:

- Root level: .env
- Frontend level: .env

Let's keep only root-level .env files — they control everything via Docker Compose. The frontend-level files are redundant and cause confusion. Now there is a single source of truth (root .env).
