### PR TITLE
profile settings to show actual email and ID

### DIFF
--- a/frontend/office/src/pages/ProfilePage.tsx
+++ b/frontend/office/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 type MeResponse = {
   id: string;

--- a/frontend/office/src/pages/ProfilePage.tsx
+++ b/frontend/office/src/pages/ProfilePage.tsx
@@ -1,3 +1,5 @@
+import React, { useEffect, useState } from "react";
+
 type MeResponse = {
   id: string;
   email: string;
@@ -6,16 +8,41 @@ type MeResponse = {
   is_active: boolean;
 };
 
-const DUMMY_ME: MeResponse = {
-  id: '2e3fca16-4f5a-4af7-9739-df2b6fa8baf4',
-  email: 'chef-admin@voicechef.local',
-  tenant_id: '0b796544-6414-4d62-8f1f-cd2f9f0ac0a0',
-  role: 'editor',
-  is_active: true,
-};
-
 export function ProfilePage() {
-  const me = DUMMY_ME;
+  const [me, setMe] = useState<MeResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    async function loadMe() {
+      try {
+        const resp = await fetch("/api/auth/me", { credentials: "same-origin" });
+        if (!resp.ok) {
+          if (resp.status === 401) {
+            if (!mounted) return;
+            setError("Not authenticated");
+            setLoading(false);
+            return;
+          }
+          throw new Error(`Failed to load profile (${resp.status})`);
+        }
+        const data = (await resp.json()) as MeResponse;
+        if (!mounted) return;
+        setMe(data);
+      } catch (err: any) {
+        if (!mounted) return;
+        setError(err?.message ?? String(err));
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }
+
+    loadMe();
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -23,29 +50,38 @@ export function ProfilePage() {
         <h1 className="text-2xl font-semibold">Profile settings</h1>
         <p className="text-muted-foreground">Manage your profile information and settings.</p>
       </div>
+
       <div className="rounded-lg border p-6">
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div>
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">User ID</p>
-            <p className="text-sm font-medium break-all">{me.id}</p>
+        {loading ? (
+          <p>Loading profile…</p>
+        ) : error ? (
+          <p className="text-destructive">Error: {error}</p>
+        ) : me ? (
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">User ID</p>
+              <p className="text-sm font-medium break-all">{me.id}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Email</p>
+              <p className="text-sm font-medium break-all">{me.email}</p>
+            </div>
+            {/* <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Tenant ID</p>
+              <p className="text-sm font-medium break-all">{me.tenant_id}</p>
+            </div> */}
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Role</p>
+              <p className="text-sm font-medium">{me.role}</p>
+            </div>
+            {/* <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Active</p>
+              <p className="text-sm font-medium">{me.is_active ? "Yes" : "No"}</p>
+            </div> */}
           </div>
-          <div>
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Email</p>
-            <p className="text-sm font-medium break-all">{me.email}</p>
-          </div>
-          <div>
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Tenant ID</p>
-            <p className="text-sm font-medium break-all">{me.tenant_id}</p>
-          </div>
-          <div>
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Role</p>
-            <p className="text-sm font-medium">{me.role}</p>
-          </div>
-          <div>
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Active</p>
-            <p className="text-sm font-medium">{me.is_active ? 'Yes' : 'No'}</p>
-          </div>
-        </div>
+        ) : (
+          <p>No profile data available.</p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Before, dummy data was used.
Now, actual email and user ID are shown.

I wish we could also show tenant ID, but it's not returned by endpoint.
Thus, it's currently commented out in code.