### PR TITLE
Files page - File upload progress indicator implemented

### DIFF
--- a/backend/app/utils/file_service_pdfs_utils.py
+++ b/backend/app/utils/file_service_pdfs_utils.py
@@ -1,12 +1,14 @@
 import os
 import re
+import shutil
+import tempfile
 from fastapi import UploadFile, HTTPException
 from app.core.config import settings
 
 UPLOAD_DIR = settings.UPLOAD_DIR
 UPLOAD_URL_PREFIX = settings.UPLOAD_URL_PREFIX
 
-MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+MAX_FILE_SIZE = 100 * 1024 * 1024  # 10 MB
 ALLOWED_CONTENT_TYPES = {"application/pdf"}
 
 
@@ -40,18 +42,6 @@ def save_pdf(file: UploadFile) -> str:
     if file.content_type not in ALLOWED_CONTENT_TYPES:
         raise HTTPException(400, "Only PDF files are allowed")
 
-    contents = file.file.read()
-    
-    # Size validation
-    if len(contents) == 0:
-        raise HTTPException(400, "File is empty")
-    if len(contents) > MAX_FILE_SIZE:
-        raise HTTPException(400, "File too large (max 10MB)")
-  
-    # Format validation
-    if not is_pdf_file(contents):
-        raise HTTPException(400, "Invalid PDF file")
-
     filename = sanitize_filename(file.filename)
 
     if not filename.lower().endswith(".pdf"):
@@ -60,10 +50,44 @@ def save_pdf(file: UploadFile) -> str:
     # File name and path generation
     filename = ensure_unique_filename(filename)
     file_path = os.path.join(UPLOAD_DIR, filename)
-  
-    # Save/write file
-    with open(file_path, "wb") as f:
-        f.write(contents)
+
+    temp_file = None
+    temp_path = None
+
+    try:
+        # Stream the upload to a temporary file first so validation doesn't
+        # require loading the entire file into memory.
+        temp_file = tempfile.NamedTemporaryFile(
+            delete=False,
+            dir=UPLOAD_DIR,
+            suffix=".upload",
+        )
+        temp_path = temp_file.name
+        temp_file.close()
+
+        with open(temp_path, "wb") as f:
+            shutil.copyfileobj(file.file, f)
+
+        file_size = os.path.getsize(temp_path)
+
+        # Size validation
+        if file_size == 0:
+            raise HTTPException(400, "File is empty")
+        if file_size > MAX_FILE_SIZE:
+            raise HTTPException(400, "File too large (max 10MB)")
+
+        # Format validation using the temp file header
+        with open(temp_path, "rb") as f:
+            header = f.read(5)
+            if not is_pdf_file(header):
+                raise HTTPException(400, "Invalid PDF file")
+
+        shutil.move(temp_path, file_path)
+        temp_path = None
+
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.remove(temp_path)
 
     return f"{UPLOAD_URL_PREFIX}/{filename}"
 

--- a/frontend/office/src/api/pdfs.ts
+++ b/frontend/office/src/api/pdfs.ts
@@ -1,4 +1,5 @@
 import { api } from './axios';
+import type { AxiosProgressEvent } from 'axios';
 import { useQuery } from '@tanstack/react-query';
 
 export interface PDFFile {
@@ -26,7 +27,10 @@ export const deletePDF = async (filename: string) => {
   await api.delete(`/pdfs/${filename}`);
 };
 
-export const uploadPDF = (file: File) => {
+export const uploadPDF = (
+  file: File,
+  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
+) => {
   const formData = new FormData();
   formData.append('file', file);
 
@@ -34,5 +38,6 @@ export const uploadPDF = (file: File) => {
     headers: {
       'Content-Type': 'multipart/form-data',
     },
+    onUploadProgress,
   });
 };

--- a/frontend/office/src/pages/FilesPage.tsx
+++ b/frontend/office/src/pages/FilesPage.tsx
@@ -1,7 +1,7 @@
 import { usePDFs, uploadPDF, deletePDF, getPDFUrl } from '@/api/pdfs';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
-import { useState, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Delete02Icon } from '@hugeicons/core-free-icons';
@@ -17,14 +17,48 @@ function formatFileSize(bytes: number): string {
 export function FilesPage() {
   const { data: pdfs = [], isLoading, error } = usePDFs();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const uploadSuccessTimerRef = useRef<number | null>(null);
   const queryClient = useQueryClient();
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploadSuccess, setUploadSuccess] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState<number>(0);
+  const [uploadBytesLoaded, setUploadBytesLoaded] = useState<number>(0);
+  const [uploadBytesTotal, setUploadBytesTotal] = useState<number>(0);
+  const [uploadFileName, setUploadFileName] = useState<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (uploadSuccessTimerRef.current) {
+        window.clearTimeout(uploadSuccessTimerRef.current);
+      }
+    };
+  }, []);
 
   const uploadMutation = useMutation({
-    mutationFn: uploadPDF,
+    mutationFn: ({
+      file,
+      onProgress,
+    }: {
+      file: File;
+      onProgress?: Parameters<typeof uploadPDF>[1];
+    }) => uploadPDF(file, onProgress),
     onSuccess: () => {
       setUploadError(null);
+      setUploadSuccess('File uploaded successfully');
+      setUploadProgress(0);
+      setUploadBytesLoaded(0);
+      setUploadBytesTotal(0);
+      setUploadFileName(null);
+
+      if (uploadSuccessTimerRef.current) {
+        window.clearTimeout(uploadSuccessTimerRef.current);
+      }
+      uploadSuccessTimerRef.current = window.setTimeout(() => {
+        setUploadSuccess(null);
+        uploadSuccessTimerRef.current = null;
+      }, 3000);
+
       queryClient.invalidateQueries({ queryKey: ['pdfs'] });
       if (fileInputRef.current) {
         fileInputRef.current.value = '';
@@ -32,6 +66,11 @@ export function FilesPage() {
     },
     onError: (err: any) => {
       setUploadError(err?.response?.data?.detail || 'Failed to upload file');
+      setUploadSuccess(null);
+      setUploadProgress(0);
+      setUploadBytesLoaded(0);
+      setUploadBytesTotal(0);
+      setUploadFileName(null);
     },
   });
 
@@ -49,7 +88,21 @@ export function FilesPage() {
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      uploadMutation.mutate(file);
+      setUploadError(null);
+      setUploadFileName(file.name);
+      setUploadBytesTotal(file.size);
+      setUploadBytesLoaded(0);
+      setUploadProgress(0);
+
+      uploadMutation.mutate({
+        file,
+        onProgress: (progressEvent) => {
+          if (!progressEvent.total) return;
+          setUploadBytesLoaded(progressEvent.loaded);
+          setUploadBytesTotal(progressEvent.total);
+          setUploadProgress(Math.round((progressEvent.loaded / progressEvent.total) * 100));
+        },
+      });
     }
   };
 
@@ -82,6 +135,32 @@ export function FilesPage() {
           {uploadMutation.isPending ? 'Uploading...' : 'Upload PDF'}
         </Button>
       </div>
+
+      {uploadSuccess && (
+        <div className="rounded-lg bg-green-50 p-4 text-sm text-green-700 border border-green-200">
+          {uploadSuccess}
+        </div>
+      )}
+
+      {uploadMutation.isPending && uploadFileName && (
+        <div className="space-y-2 rounded-lg border bg-muted/20 p-4">
+          <div className="flex items-center justify-between gap-4 text-sm">
+            <div className="min-w-0">
+              <p className="font-medium truncate">Uploading {uploadFileName}</p>
+              <p className="text-muted-foreground">
+                {formatFileSize(uploadBytesLoaded)} / {formatFileSize(uploadBytesTotal)}
+              </p>
+            </div>
+            <p className="shrink-0 font-semibold">{uploadProgress}%</p>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-200 ease-out"
+              style={{ width: `${uploadProgress}%` }}
+            />
+          </div>
+        </div>
+      )}
 
       {uploadError && (
         <div className="p-4 bg-destructive/10 text-destructive rounded-md">


### PR DESCRIPTION

This pull request introduces improvements to the PDF file upload processbar  in both the backend and frontend.

The backend now streams uploads to disk to avoid loading large files into memory and increases the maximum allowed file size to 100MB. 

The frontend adds real-time upload progress tracking, user feedback for upload success, and improved error handling.

Test:
Upload a pdf file in Files section and see upload progress indicator && success messsage upon completion.