### PR TITLE
[security/bug-fix] Remove hardcoded database credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,22 @@
 # Shared secret for agent→backend internal auth bypass.
 # Only the agent service sends this header. Browser requests never do.
-# Change to a long random string in production. openssl rand -base64 32
+# Change to a long random string in production.
+# run `openssl rand -base64 32`
 INTERNAL_SECRET=your-long-random-string-here
 
 # Database env
-POSTGRES_DB=recipe_db
-POSTGRES_USER=recipe_user
-POSTGRES_PASSWORD=recipe_pass123
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@db:5432/recipe_db
+POSTGRES_DB=
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+DATABASE_URL=postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+
+# Local database URL for running schema drift tests (make drift-gate-local).
+# Uses localhost hostname instead of 'db' (Docker hostname).
+# Required: DATABASE_URL_LOCAL must use localhost for local alembic migrations to work.
+DATABASE_URL_LOCAL=postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}
 
 # Backend env
-SQL_ECHO=1
+SQL_ECHO=0
 DEFAULT_TENANT_ID=0b796544-6414-4d62-8f1f-cd2f9f0ac0a0
 
 # jwt secret

--- a/.env.example
+++ b/.env.example
@@ -10,11 +10,6 @@ POSTGRES_USER=
 POSTGRES_PASSWORD=
 DATABASE_URL=postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
 
-# Local database URL for running schema drift tests (make drift-gate-local).
-# Uses localhost hostname instead of 'db' (Docker hostname).
-# Required: DATABASE_URL_LOCAL must use localhost for local alembic migrations to work.
-DATABASE_URL_LOCAL=postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}
-
 # Backend env
 SQL_ECHO=0
 DEFAULT_TENANT_ID=0b796544-6414-4d62-8f1f-cd2f9f0ac0a0

--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -140,7 +140,7 @@ jobs:
         image: postgres:17-alpine
         env:
           POSTGRES_USER: recipe_user
-          POSTGRES_PASSWORD: recipe_pass123
+          POSTGRES_PASSWORD: ${{ secrets.CI_POSTGRES_PASSWORD }}
           POSTGRES_DB: recipe_db
         ports:
           - 5432:5432
@@ -151,7 +151,7 @@ jobs:
           --health-retries 5
 
     env:
-      DATABASE_URL: postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db
+      DATABASE_URL: postgresql+psycopg://recipe_user:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/recipe_db
       PYTHONPATH: ./fastapi
       DRIFT_LOG_FILE: logs/drift_gate_dump_compat_ci.log
 
@@ -173,12 +173,12 @@ jobs:
 
       - name: Bootstrap dump-init schema
         run: |
-          PGPASSWORD=recipe_pass123 psql \
+          PGPASSWORD=${{ secrets.CI_POSTGRES_PASSWORD }} psql \
             -h localhost -U recipe_user -d recipe_db \
             -v ON_ERROR_STOP=1 \
             -f db/init/01_dump.sql
 
-          PGPASSWORD=recipe_pass123 psql \
+          PGPASSWORD=${{ secrets.CI_POSTGRES_PASSWORD }} psql \
             -h localhost -U recipe_user -d recipe_db \
             -v ON_ERROR_STOP=1 \
             -f db/init/02_align_alembic_revision.sql

--- a/Makefile
+++ b/Makefile
@@ -190,12 +190,16 @@ refresh-env-agent: $(ENV)
 # ── Database targets ───────────────────────────────────────────────────────
 
 # Run all four schema-drift gates locally (strict check).
-drift-gate-local:
-    @echo "Ensuring database is running..."
-    $(COMPOSE) -f $(PROD_FILE) up -d db
-    @sleep 2
+drift-gate-local: $(ENV)
+	@echo "Ensuring database is running..."
+	$(COMPOSE) -f $(PROD_FILE) up -d db
+	@sleep 2
 	@echo "Running local 4-gate schema drift check..."
-	chmod +x db/scripts/run_local_drift_gate.sh
+	@chmod +x db/scripts/run_local_drift_gate.sh
+	@DB_USER=$$(grep POSTGRES_USER .env | cut -d= -f2); \
+	DB_PASS=$$(grep POSTGRES_PASSWORD .env | cut -d= -f2); \
+	DB_NAME=$$(grep POSTGRES_DB .env | cut -d= -f2); \
+	export DATABASE_URL="postgresql+psycopg://$$DB_USER:$$DB_PASS@localhost:5432/$$DB_NAME"; \
 	./db/scripts/run_local_drift_gate.sh
 	@echo "Done: local schema drift gate passed"
 

--- a/Makefile
+++ b/Makefile
@@ -191,15 +191,25 @@ refresh-env-agent: $(ENV)
 
 # Run all four schema-drift gates locally (strict check).
 drift-gate-local:
-	@bash -c 'cd backend && python -m pytest tests/test_drift_gate.py -v'
+    @echo "Ensuring database is running..."
+    $(COMPOSE) -f $(PROD_FILE) up -d db
+    @sleep 2
+	@echo "Running local 4-gate schema drift check..."
+	chmod +x db/scripts/run_local_drift_gate.sh
+	./db/scripts/run_local_drift_gate.sh
+	@echo "Done: local schema drift gate passed"
 
 # Blast-test: wipe DB volume, re-initialize from dump, then run alembic upgrade.
 dump-blast-check:
-	@bash -c 'cd backend && python scripts/dump_blast_check.py'
+	chmod +x db/scripts/dump_upgrade_blast_check.sh
+	./db/scripts/dump_upgrade_blast_check.sh
 
 # Regenerate db/init/01_dump.sql from the current migration head.
 dump-regen:
-	@bash -c 'cd backend && python scripts/dump_regenerate.py'
+	@echo "Regenerating db/init/01_dump.sql from migration head (isolated temp DB)..."
+	chmod +x db/scripts/regenerate_dump_from_head.sh
+	./db/scripts/regenerate_dump_from_head.sh
+	@echo "Done: db/init/01_dump.sql regenerated from migration head"
 
 # Open a psql shell inside the running db container.
 db-connect:

--- a/Makefile
+++ b/Makefile
@@ -189,24 +189,24 @@ refresh-env-agent: $(ENV)
 
 # ── Database targets ───────────────────────────────────────────────────────
 
+LOCAL_DB_URL = $$( \
+    USER=$$(grep POSTGRES_USER .env | cut -d= -f2); \
+    PASS=$$(grep POSTGRES_PASSWORD .env | cut -d= -f2); \
+    NAME=$$(grep POSTGRES_DB .env | cut -d= -f2); \
+    echo "postgresql+psycopg://$$USER:$$PASS@localhost:5432/$$NAME" \
+)
+
 # Run all four schema-drift gates locally (strict check).
 drift-gate-local: $(ENV)
-	@echo "Ensuring database is running..."
-	$(COMPOSE) -f $(PROD_FILE) up -d db
-	@sleep 2
 	@echo "Running local 4-gate schema drift check..."
 	@chmod +x db/scripts/run_local_drift_gate.sh
-	@DB_USER=$$(grep POSTGRES_USER .env | cut -d= -f2); \
-	DB_PASS=$$(grep POSTGRES_PASSWORD .env | cut -d= -f2); \
-	DB_NAME=$$(grep POSTGRES_DB .env | cut -d= -f2); \
-	export DATABASE_URL="postgresql+psycopg://$$DB_USER:$$DB_PASS@localhost:5432/$$DB_NAME"; \
-	./db/scripts/run_local_drift_gate.sh
+	@DATABASE_URL=$(LOCAL_DB_URL) ./db/scripts/run_local_drift_gate.sh
 	@echo "Done: local schema drift gate passed"
 
 # Blast-test: wipe DB volume, re-initialize from dump, then run alembic upgrade.
 dump-blast-check:
-	chmod +x db/scripts/dump_upgrade_blast_check.sh
-	./db/scripts/dump_upgrade_blast_check.sh
+	@chmod +x db/scripts/dump_upgrade_blast_check.sh
+	@DATABASE_URL=$(LOCAL_DB_URL) ./db/scripts/dump_upgrade_blast_check.sh
 
 # Regenerate db/init/01_dump.sql from the current migration head.
 dump-regen:

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,7 +1,10 @@
 [alembic]
 script_location = db/alembic
 prepend_sys_path = %(here)s
-sqlalchemy.url = postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db
+# db/alembic/env.py is set up to read from the DATABASE_URL environment variable.
+# It prioritizes DATABASE_URL from your .env file and only falls back to the 
+# hardcoded URL in alembic.ini if the env var isn't set.
+sqlalchemy.url = 
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 set -e
 
-export DATABASE_URL=${DATABASE_URL:-postgresql+psycopg://recipe_user:recipe_pass123@db:5432/recipe_db}
+if [ -z "$DATABASE_URL" ]; then
+  echo "ERROR: DATABASE_URL environment variable is not set"
+  exit 1
+fi
 export PYTHONPATH=/code
 
 # Wait for the database to be ready, apply migrations, then start the application server

--- a/db/scripts/dump_upgrade_blast_check.sh
+++ b/db/scripts/dump_upgrade_blast_check.sh
@@ -1,27 +1,18 @@
 #!/usr/bin/env bash
+# IMPORTANT: Run this test locally from Makefile
+
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
-
-# Load environment variables from .env
-if [ -f "$ROOT_DIR/.env" ]; then
-    set -a
-    source "$ROOT_DIR/.env"
-    set +a
-fi
 
 LOG_DIR="logs"
 LOG_FILE="$LOG_DIR/dump_upgrade_blast_check.log"
 
 mkdir -p "$LOG_DIR"
 
-# DATABASE_URL must be set (from .env)
-if [ -z "${DATABASE_URL:-}" ]; then
-  echo "ERROR: DATABASE_URL environment variable is not set"
-  exit 1
-fi
-DB_URL="$DATABASE_URL"
+# Provide DATABASE_URL
+export DATABASE_URL="${DATABASE_URL:-}"
 
 # Extract PostgreSQL credentials from environment
 DB_USER="${POSTGRES_USER:-recipe_user}"
@@ -71,9 +62,12 @@ for i in $(seq 1 40); do
   sleep 2
 done
 
+echo "[blast-check] additional 5 second wait for post-dump stabilization" | tee -a "$LOG_FILE"
+sleep 5
+
 echo "[blast-check] running alembic upgrade head against dump-initialized db" | tee -a "$LOG_FILE"
 set +e
-.venv/bin/alembic -c alembic.ini -x db_url="$DB_URL" upgrade head >> "$LOG_FILE" 2>&1
+.venv/bin/alembic -c alembic.ini -x db_url="$DATABASE_URL" upgrade head >> "$LOG_FILE" 2>&1
 ALEMBIC_EXIT=$?
 set -e
 

--- a/db/scripts/dump_upgrade_blast_check.sh
+++ b/db/scripts/dump_upgrade_blast_check.sh
@@ -4,12 +4,24 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+# Load environment variables from .env
+if [ -f "$ROOT_DIR/.env" ]; then
+    set -a
+    source "$ROOT_DIR/.env"
+    set +a
+fi
+
 LOG_DIR="logs"
 LOG_FILE="$LOG_DIR/dump_upgrade_blast_check.log"
 
 mkdir -p "$LOG_DIR"
 
-DB_URL="${DATABASE_URL:-postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db}"
+# DATABASE_URL_LOCAL must be set (from .env)
+if [ -z "${DATABASE_URL_LOCAL:-}" ]; then
+  echo "ERROR: DATABASE_URL_LOCAL environment variable is not set"
+  exit 1
+fi
+DB_URL="$DATABASE_URL_LOCAL"
 
 {
   echo "[blast-check] started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/db/scripts/dump_upgrade_blast_check.sh
+++ b/db/scripts/dump_upgrade_blast_check.sh
@@ -16,12 +16,17 @@ LOG_FILE="$LOG_DIR/dump_upgrade_blast_check.log"
 
 mkdir -p "$LOG_DIR"
 
-# DATABASE_URL_LOCAL must be set (from .env)
-if [ -z "${DATABASE_URL_LOCAL:-}" ]; then
-  echo "ERROR: DATABASE_URL_LOCAL environment variable is not set"
+# DATABASE_URL must be set (from .env)
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "ERROR: DATABASE_URL environment variable is not set"
   exit 1
 fi
-DB_URL="$DATABASE_URL_LOCAL"
+DB_URL="$DATABASE_URL"
+
+# Extract PostgreSQL credentials from environment
+DB_USER="${POSTGRES_USER:-recipe_user}"
+DB_NAME="${POSTGRES_DB:-recipe_db}"
+DB_PASS="${POSTGRES_PASSWORD:-}"
 
 {
   echo "[blast-check] started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -35,7 +40,7 @@ docker compose up -d db >> "$LOG_FILE" 2>&1
 
 echo "[blast-check] waiting for db health" | tee -a "$LOG_FILE"
 for i in $(seq 1 30); do
-  if docker compose exec -T db pg_isready -U recipe_user -d recipe_db >/dev/null 2>&1; then
+  if docker compose exec -T db pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null 2>&1; then
     echo "[blast-check] db is healthy" | tee -a "$LOG_FILE"
     break
   fi
@@ -49,7 +54,7 @@ done
 echo "[blast-check] waiting for stable SQL connectivity" | tee -a "$LOG_FILE"
 stable_ok=0
 for i in $(seq 1 40); do
-  if docker compose exec -T db psql -U recipe_user -d recipe_db -c "SELECT 1;" >/dev/null 2>&1; then
+  if docker compose exec -T db psql -U "$DB_USER" -d "$DB_NAME" -c "SELECT 1;" >/dev/null 2>&1; then
     stable_ok=$((stable_ok + 1))
     if [[ "$stable_ok" -ge 2 ]]; then
       echo "[blast-check] SQL connectivity is stable" | tee -a "$LOG_FILE"
@@ -75,7 +80,7 @@ set -e
 echo "[blast-check] alembic exit code: $ALEMBIC_EXIT" | tee -a "$LOG_FILE"
 
 echo "[blast-check] current alembic_version rows:" | tee -a "$LOG_FILE"
-docker compose exec -T db psql -U recipe_user -d recipe_db -c "SELECT version_num FROM alembic_version;" >> "$LOG_FILE" 2>&1 || true
+docker compose exec -T db psql -U "$DB_USER" -d "$DB_NAME" -c "SELECT version_num FROM alembic_version;" >> "$LOG_FILE" 2>&1 || true
 
 echo "[blast-check] finished: $(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee -a "$LOG_FILE"
 

--- a/db/scripts/regenerate_dump_from_head.sh
+++ b/db/scripts/regenerate_dump_from_head.sh
@@ -4,11 +4,18 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+# Load environment variables from .env
+if [ -f "$ROOT_DIR/.env" ]; then
+    set -a
+    source "$ROOT_DIR/.env"
+    set +a
+fi
+
 TMP_CONTAINER="vc_dump_regen_db"
 TMP_PORT="55432"
 DB_NAME="recipe_db"
 DB_USER="recipe_user"
-DB_PASS="recipe_pass123"
+DB_PASS="$POSTGRES_PASSWORD"
 DB_URL="postgresql+psycopg://${DB_USER}:${DB_PASS}@localhost:${TMP_PORT}/${DB_NAME}"
 
 cleanup() {

--- a/db/scripts/run_local_drift_gate.sh
+++ b/db/scripts/run_local_drift_gate.sh
@@ -41,7 +41,7 @@ if [ -z "$ALEMBIC" ] || [ -z "$PYTHON" ] || [ -z "$PYTEST" ]; then
 fi
 
 # Provide DATABASE_URL for drift_check.py and pytest conftest if not already set
-export DATABASE_URL="${DATABASE_URL_LOCAL}"
+export DATABASE_URL="${DATABASE_URL_LOCAL:-}"
 
 LOG_FILE="${DRIFT_LOG_FILE:-logs/drift_gate_local.log}"
 PENDING_REV_ID="${PENDING_REV_ID:-pending_check_tmp_local}"

--- a/db/scripts/run_local_drift_gate.sh
+++ b/db/scripts/run_local_drift_gate.sh
@@ -41,7 +41,7 @@ if [ -z "$ALEMBIC" ] || [ -z "$PYTHON" ] || [ -z "$PYTEST" ]; then
 fi
 
 # Provide DATABASE_URL for drift_check.py and pytest conftest if not already set
-export DATABASE_URL="${DATABASE_URL_LOCAL:-}"
+export DATABASE_URL="${DATABASE_URL:-}"
 
 LOG_FILE="${DRIFT_LOG_FILE:-logs/drift_gate_local.log}"
 PENDING_REV_ID="${PENDING_REV_ID:-pending_check_tmp_local}"

--- a/db/scripts/run_local_drift_gate.sh
+++ b/db/scripts/run_local_drift_gate.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# IMPORTANT: Run this test locally from Makefile
 
 set -u
 
@@ -10,12 +11,14 @@ if [ -f "$ROOT_DIR/.venv/bin/activate" ]; then
     source "$ROOT_DIR/.venv/bin/activate"
 fi
 
-# Load environment variables from .env
-if [ -f "$ROOT_DIR/.env" ]; then
-    set -a
-    source "$ROOT_DIR/.env"
-    set +a
+# DATABASE_URL must be set (in Makefile)
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "ERROR: DATABASE_URL environment variable is not set"
+  exit 1
 fi
+
+# Provide DATABASE_URL for drift_check.py and pytest conftest if not already set
+export DATABASE_URL="${DATABASE_URL:-}"
 
 if [ -x "$ROOT_DIR/.venv/bin/alembic" ]; then
     ALEMBIC="$ROOT_DIR/.venv/bin/alembic"
@@ -39,9 +42,6 @@ if [ -z "$ALEMBIC" ] || [ -z "$PYTHON" ] || [ -z "$PYTEST" ]; then
     echo "Missing required tools: alembic/python/pytest must be installed and discoverable on PATH." >&2
     exit 127
 fi
-
-# Provide DATABASE_URL for drift_check.py and pytest conftest if not already set
-export DATABASE_URL="${DATABASE_URL:-}"
 
 LOG_FILE="${DRIFT_LOG_FILE:-logs/drift_gate_local.log}"
 PENDING_REV_ID="${PENDING_REV_ID:-pending_check_tmp_local}"

--- a/db/scripts/run_local_drift_gate.sh
+++ b/db/scripts/run_local_drift_gate.sh
@@ -10,6 +10,13 @@ if [ -f "$ROOT_DIR/.venv/bin/activate" ]; then
     source "$ROOT_DIR/.venv/bin/activate"
 fi
 
+# Load environment variables from .env
+if [ -f "$ROOT_DIR/.env" ]; then
+    set -a
+    source "$ROOT_DIR/.env"
+    set +a
+fi
+
 if [ -x "$ROOT_DIR/.venv/bin/alembic" ]; then
     ALEMBIC="$ROOT_DIR/.venv/bin/alembic"
 else
@@ -34,7 +41,7 @@ if [ -z "$ALEMBIC" ] || [ -z "$PYTHON" ] || [ -z "$PYTEST" ]; then
 fi
 
 # Provide DATABASE_URL for drift_check.py and pytest conftest if not already set
-export DATABASE_URL="${DATABASE_URL:-postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db}"
+export DATABASE_URL="${DATABASE_URL_LOCAL}"
 
 LOG_FILE="${DRIFT_LOG_FILE:-logs/drift_gate_local.log}"
 PENDING_REV_ID="${PENDING_REV_ID:-pending_check_tmp_local}"

--- a/db/test/conftest.py
+++ b/db/test/conftest.py
@@ -5,7 +5,6 @@ from sqlalchemy.pool import NullPool
 from alembic.config import Config
 
 
-# NOTE: mpeshko - DATABASE_URL or DATABASE_URL_LOCAL???
 # DATABASE_URL must be set (from .env or environment)
 TEST_DB_URL = os.environ.get("DATABASE_URL")
 if not TEST_DB_URL:

--- a/db/test/conftest.py
+++ b/db/test/conftest.py
@@ -5,10 +5,14 @@ from sqlalchemy.pool import NullPool
 from alembic.config import Config
 
 
-TEST_DB_URL = os.environ.get(
-    "DATABASE_URL",
-    "postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db",
-)
+# NOTE: mpeshko - DATABASE_URL or DATABASE_URL_LOCAL???
+# DATABASE_URL must be set (from .env or environment)
+TEST_DB_URL = os.environ.get("DATABASE_URL")
+if not TEST_DB_URL:
+    raise RuntimeError(
+        "DATABASE_URL environment variable is not set. "
+        "Please set it before running tests (e.g., from .env file)."
+    )
 
 
 @pytest.fixture(scope="session")

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -60,25 +60,33 @@ Manual equivalent:
 1. Migration state check:
 
 ```bash
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
 .venv/bin/alembic -c alembic.ini -x db_url="$DATABASE_URL" current
 ```
 
 2. Programmatic drift check:
 
 ```bash
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
 .venv/bin/python db/scripts/drift_check.py
 ```
 
 3. Pytest drift suite:
 
 ```bash
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
 .venv/bin/pytest db/test/test_schema_drift.py --test-alembic -q
 ```
 
 4. Pending-autogenerate check (manual review):
 
 ```bash
-DATABASE_URL="$DATABASE_URL" .venv/bin/alembic -c alembic.ini revision --autogenerate -m "drift_check_tmp"
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+.venv/bin/alembic -c alembic.ini revision --autogenerate -m "drift_check_tmp"
 ```
 
 If the generated revision contains no operations, pending drift is effectively zero. Delete the temporary revision after review.
@@ -96,6 +104,8 @@ Note:
 Check only Users/Tenants/Recipes:
 
 ```bash
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
 .venv/bin/python db/scripts/drift_check.py --class Users --class Tenants --class Recipes
 .venv/bin/pytest db/test/test_schema_drift.py --test-alembic --drift-class Users --drift-class Tenants --drift-class Recipes -q
 ```
@@ -103,6 +113,8 @@ Check only Users/Tenants/Recipes:
 Check one table only:
 
 ```bash
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
 .venv/bin/python db/scripts/drift_check.py --table users
 ```
 
@@ -127,6 +139,8 @@ If scope is small but many files are listed, that is expected. Only `Effective s
 
 1. Create migration file (after model change):
 ```bash
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
 .venv/bin/alembic revision -m "describe_change"
 ```
 
@@ -305,7 +319,9 @@ Use this flow on legacy databases restored from dump files where canonical 002 f
 1. Apply reconciliation migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 004
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+.venv/bin/alembic upgrade 004
 ```
 
 2. Run canonical backfill (quantity_grams, price_per_gram, recipe totals):
@@ -337,7 +353,9 @@ Rules used by the view:
 Apply migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 005
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+.venv/bin/alembic upgrade 005
 ```
 
 Example usage:
@@ -358,7 +376,9 @@ If you need to override these defaults with your own business values, use the sc
 Apply migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 006
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+.venv/bin/alembic upgrade 006
 ```
 
 1. Fill grams-per-piece values for the exact 7 unresolved ingredients:
@@ -395,7 +415,9 @@ What it preserves:
 Apply migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 007
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+.venv/bin/alembic upgrade 007
 ```
 
 Verify canonical rows and moved price history:
@@ -416,7 +438,9 @@ preserving all links and metadata.
 Apply migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 008
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+.venv/bin/alembic upgrade 008
 ```
 
 Verify canonical rows and moved price history:
@@ -437,8 +461,10 @@ for ingredients with existing recipes.
 1. Apply migrations:
 
 ```bash
-DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 009
-DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 010
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+.venv/bin/alembic upgrade 009
+.venv/bin/alembic upgrade 010
 ```
 
 2. Review price policy and backfill scripts in `db/scripts/`:
@@ -468,13 +494,17 @@ Alembic `011` applies the approved cleanup scope:
 Apply migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 011
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+.venv/bin/alembic upgrade 011
 ```
 
 Rollback this cleanup only:
 
 ```bash
-DATABASE_URL=${DATABASE_URL} .venv/bin/alembic downgrade 010
+source .env
+export DATABASE_URL="postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+.venv/bin/alembic downgrade 010
 ```
 
 Notes:

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -24,11 +24,22 @@ Use this section for fast schema parity checks before/after model changes.
 
 ### 1) Prerequisites
 
+Ensure you have a Python virtual environment set up with all dependencies installed:
+
 ```bash
-docker compose up -d db
+python3 -m venv .venv
 source .venv/bin/activate
-export DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db
-```
+
+# Install dependencies
+pip install -r backend/requirements.txt
+
+# Ensure pytest and pytest-alembic are installed and up-to-date (required for drift gate)
+pip install -U pytest pytest-alembic
+
+# Start database service
+docker compose up -d db
+
+**Important:** The `.venv/bin/activate` must be sourced in your current shell session before running any `make` commands. If you get "Missing required tools: alembic/python/pytest", it means the venv is not activated.
 
 ### 2) Full gate (all metadata)
 
@@ -116,7 +127,7 @@ If scope is small but many files are listed, that is expected. Only `Effective s
 
 1. Create migration file (after model change):
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic revision -m "describe_change"
+.venv/bin/alembic revision -m "describe_change"
 ```
 
 2. Edit the new file under:
@@ -124,12 +135,12 @@ DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/reci
 
 3. Apply locally:
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic upgrade head
+.venv/bin/alembic upgrade head
 ```
 
 4. Verify current revision:
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic current
+.venv/bin/alembic current
 ```
 
 5. Rebuild/restart app when requirements or startup behavior changed:
@@ -144,7 +155,7 @@ docker compose exec -T db pg_dump -U recipe_user -d recipe_db > db/backups/pre_c
 
 7. Roll back one step if needed:
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic downgrade -1
+.venv/bin/alembic downgrade -1
 ```
 
 ## How container stays up to date now
@@ -294,7 +305,7 @@ Use this flow on legacy databases restored from dump files where canonical 002 f
 1. Apply reconciliation migration:
 
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic upgrade 004
+DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 004
 ```
 
 2. Run canonical backfill (quantity_grams, price_per_gram, recipe totals):
@@ -326,7 +337,7 @@ Rules used by the view:
 Apply migration:
 
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic upgrade 005
+DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 005
 ```
 
 Example usage:
@@ -347,7 +358,7 @@ If you need to override these defaults with your own business values, use the sc
 Apply migration:
 
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic upgrade 006
+DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 006
 ```
 
 1. Fill grams-per-piece values for the exact 7 unresolved ingredients:
@@ -384,7 +395,7 @@ What it preserves:
 Apply migration:
 
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic upgrade 007
+DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 007
 ```
 
 Verify canonical rows and moved price history:
@@ -405,7 +416,7 @@ preserving all links and metadata.
 Apply migration:
 
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic upgrade 008
+DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 008
 ```
 
 Verify canonical rows and moved price history:
@@ -426,8 +437,8 @@ for ingredients with existing recipes.
 1. Apply migrations:
 
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic upgrade 009
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic upgrade 010
+DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 009
+DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 010
 ```
 
 2. Review price policy and backfill scripts in `db/scripts/`:
@@ -457,13 +468,13 @@ Alembic `011` applies the approved cleanup scope:
 Apply migration:
 
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic upgrade 011
+DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 011
 ```
 
 Rollback this cleanup only:
 
 ```bash
-DATABASE_URL=postgresql+psycopg://recipe_user:recipe_pass123@localhost:5432/recipe_db .venv/bin/alembic downgrade 010
+DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic downgrade 010
 ```
 
 Notes:

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -305,7 +305,7 @@ Use this flow on legacy databases restored from dump files where canonical 002 f
 1. Apply reconciliation migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 004
+DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 004
 ```
 
 2. Run canonical backfill (quantity_grams, price_per_gram, recipe totals):
@@ -337,7 +337,7 @@ Rules used by the view:
 Apply migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 005
+DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 005
 ```
 
 Example usage:
@@ -358,7 +358,7 @@ If you need to override these defaults with your own business values, use the sc
 Apply migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 006
+DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 006
 ```
 
 1. Fill grams-per-piece values for the exact 7 unresolved ingredients:
@@ -395,7 +395,7 @@ What it preserves:
 Apply migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 007
+DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 007
 ```
 
 Verify canonical rows and moved price history:
@@ -416,7 +416,7 @@ preserving all links and metadata.
 Apply migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 008
+DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 008
 ```
 
 Verify canonical rows and moved price history:
@@ -437,8 +437,8 @@ for ingredients with existing recipes.
 1. Apply migrations:
 
 ```bash
-DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 009
-DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 010
+DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 009
+DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 010
 ```
 
 2. Review price policy and backfill scripts in `db/scripts/`:
@@ -468,13 +468,13 @@ Alembic `011` applies the approved cleanup scope:
 Apply migration:
 
 ```bash
-DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic upgrade 011
+DATABASE_URL=${DATABASE_URL} .venv/bin/alembic upgrade 011
 ```
 
 Rollback this cleanup only:
 
 ```bash
-DATABASE_URL=${DATABASE_URL_LOCAL} .venv/bin/alembic downgrade 010
+DATABASE_URL=${DATABASE_URL} .venv/bin/alembic downgrade 010
 ```
 
 Notes:


### PR DESCRIPTION
## HOW TO TEST

1. Open your local .env with a password for POSTGRES_PASSWORD. Search for this string in repo. It should appear only in .env.
2. Test if db drift tests aren't broken.

Run:
```bash
make drift-gate-local
```

Expected:

```
Running local 4-gate schema drift check...
RESULT migration=0 drift_script=0 pytest_drift=0 pending_autogen=0
Done: local schema drift gate passed
```

Run:
```bash
make dump-blast-check
```

Expected:

```
[blast-check] alembic exit code: 0
[blast-check] current alembic_version rows:
[blast-check] finished: 2026-05-09T10:13:26Z
```

---

## WHAT WAS DONE?

Issue #238

Security and maintainability of database configuration and migration workflows 

- Removing hardcoded database credentials
- Enforcing environment variable usage
- Updating documentation and scripts for consistency

**Environment variable and configuration improvements:**

- Removed hardcoded database credentials from `.env.example`, `.github/workflows/schema-drift.yml`, `alembic.ini`, and all migration/test scripts. Now, all scripts and services require database connection details to be provided via environment variables.

- Updated CI workflows to use GitHub secrets for database passwords instead of plaintext values, and ensured all database URLs in CI are constructed from these secrets. 
 
**Script and Makefile updates:**

- Returned OLD Makefile targets which use OLD shell scripts that load environment variables from `.env`.
 
**Documentation updates:**

- Updated `docs/migrations.md` to remove hardcoded database URLs from all commands, instruct users to activate their Python virtual environment, and consistently use environment variables for Alembic commands and migration flows.