### PR TITLE
feat(kitchen-pi): replace Pi-side frontend container with STT + kiosk only

### DIFF
--- a/docs/kitchen-pi.md
+++ b/docs/kitchen-pi.md
@@ -1,0 +1,177 @@
+# Kitchen-Pi — Custom Module (Major)
+
+## What this module is
+
+A headless kitchen kiosk: a Raspberry Pi 5 with a 7" touch display and a
+ReSpeaker microphone, running Chromium in kiosk mode against the voice-chef
+server's kitchen UI over Tailscale, with faster-whisper running locally on
+the device for sub-100ms voice transcription.
+
+## Why it deserves Major status
+
+Six distinct technical concerns, each non-trivial in isolation, integrated
+into a single deployable device:
+
+### 1. Edge ML inference
+
+faster-whisper transcribes audio on the Pi itself rather than uploading it
+to a server. Voice latency is bounded by the audio length plus model
+inference time, not by network round-trip — typical end-to-end (button
+release → transcript visible) is under 100 ms for short utterances on the
+`small` model. The same flow with server-side STT over Tailscale would add
+~150–400 ms of upload + processing RTT. For a kitchen UX where the operator
+expects "I just stopped talking" to mean "the system has my words,"
+sub-100 ms is the difference between feeling responsive and feeling
+laggy.
+
+### 2. Cross-host service discovery via Tailscale
+
+The Pi and the server typically live on different networks (kitchen LAN
+vs. office LAN, or kitchen LAN vs. home LAN). Tailscale's overlay handles
+routing and addressing without DNS configuration, port forwarding, or NAT
+punching gymnastics: `https://${SERVER_HOST}/...` resolves to the right
+host wherever both ends are. The Pi's only auto-start service on boot is
+Tailscale; everything else is brought up explicitly.
+
+### 3. Kiosk-mode Linux deployment
+
+Wayland kiosk Chromium on Pi OS Trixie, with audio routing for the ReSpeaker
+mic via a wireplumber rule, a polkit rule allowing the `voice-chef` user to
+restart the kiosk systemd unit without sudo, an XDG desktop launcher that
+exposes that capability as a "Bring back kiosk" icon, and persistent
+Chromium profile so the JWT cookie survives reboots. Each piece is small;
+together they make the device usable by a non-developer in a kitchen.
+
+### 4. Lean Pi-side checkout
+
+The Pi only carries `pi/` (configs, scripts, compose) and `stt/` (the
+Whisper service it actually runs) on disk — backend, agent, rag, and
+frontend source never touch the kiosk device. Achieved with git's
+sparse + partial clone (`--filter=blob:none` + `sparse-checkout`), so a
+fresh provisioning fetches a few MB instead of the whole repo, and
+`git pull` later respects the sparse paths automatically.
+
+### 5. Single-frontend deployment, enabled by the PWA
+
+The kitchen UI is served by the server at `https://${SERVER_HOST}/kitchen/`.
+There is no parallel kitchen-frontend container on the Pi. The PWA
+(see `docs/pwa.md`) handles offline shell + catalog caching, which is
+what the Pi-side container used to do. Removing that duplication eliminated
+parallel image builds, parallel runtime-config injection, and a Pi-side
+nginx upstream layer that drifted from the server's setup as the
+architecture evolved.
+
+### 6. Authentication flow demonstrable from a clean boot
+
+Authentication is plain JWT cookie auth, the same flow a human user goes
+through in the office UI. On a freshly-provisioned Pi, the kiosk lands on
+the login page; the kitchen-device credentials are typed in once; the
+cookie persists in the kiosk profile across reboots. Wiping the profile
+returns the Pi to its first-boot state. Nothing about the auth is
+Pi-specific — the kitchen is a regular `users` row with `role='kitchen'`,
+scoped to its tenant.
+
+## Architecture
+
+```
+┌─────────────────────────────────┐
+│ Pi (kitchen-pi)                 │      Tailscale       ┌────────────────────────┐
+│                                 │  ◄──────────────────►│ Server                 │
+│  ┌──────────────────────────┐   │   overlay network    │                        │
+│  │ Chromium kiosk           │   │                      │  ┌─────────────────┐   │
+│  │ https://${SERVER_HOST}/  │───┼──────────────────────┼─►│ nginx-proxy     │   │
+│  │   kitchen/?kiosk=1       │   │                      │  │ (HTTPS termin.) │   │
+│  └─────────┬────────────────┘   │                      │  └────┬────────────┘   │
+│            │ /stt/transcribe    │                      │       │                │
+│            ▼                    │                      │       ▼                │
+│  ┌──────────────────────────┐   │                      │  ┌─────────────────┐   │
+│  │ stt-tls (nginx)          │   │                      │  │ kitchen-frontend│   │
+│  │ https://localhost/       │   │                      │  └─────────────────┘   │
+│  └─────────┬────────────────┘   │                      │  ┌─────────────────┐   │
+│            ▼                    │                      │  │ backend         │   │
+│  ┌──────────────────────────┐   │                      │  └─────────────────┘   │
+│  │ stt (faster-whisper)     │   │                      │  ┌─────────────────┐   │
+│  │ http://localhost:8002    │   │                      │  │ agent           │   │
+│  └──────────────────────────┘   │                      │  └─────────────────┘   │
+└─────────────────────────────────┘                      │  ┌─────────────────┐   │
+                                                         │  │ rag (+ qdrant)  │   │
+                                                         │  └─────────────────┘   │
+                                                         └────────────────────────┘
+```
+
+Browser-facing traffic over Tailscale is HTTPS terminated at the server's
+nginx-proxy. Internal Compose-network traffic on the server is plain HTTP,
+which is acceptable because the network boundary is the host. Pi-local
+STT goes through the Pi-local TLS shim because the SPA loaded over HTTPS
+can't speak to plain HTTP on `localhost` (mixed-content).
+
+## Bringing it up from scratch
+
+The "from scratch" demo is exactly what `pi/scripts/start-kitchen.sh`
+demonstrates:
+
+1. Pi boots. Only Tailscale is up.
+2. SSH in, run `./pi/scripts/start-kitchen.sh`.
+3. Script generates a self-signed cert for the Pi-local STT shim (first
+   time only), brings up the STT + stt-tls containers, waits for STT to
+   become healthy, enables + starts the kiosk systemd unit.
+4. Chromium kiosk launches against `https://${SERVER_HOST}/kitchen/`,
+   lands on the login page.
+5. Authenticate with the kitchen-device credentials. The JWT cookie is
+   stored in `/home/voice-chef/.kiosk-profile`.
+6. Subsequent reboots: containers come back via `restart: unless-stopped`;
+   systemd brings the kiosk back via `WantedBy=graphical.target`; Chromium
+   reopens the kitchen URL with the same profile, cookie still valid, no
+   human interaction needed.
+
+To return the Pi to first-boot state: `./pi/scripts/reset-kitchen.sh`.
+This disables the kiosk autostart, wipes the kiosk profile (and therefore
+the cookie), and tears down the Pi-local containers. Tailscale is left
+alone.
+
+## What was rejected, and why
+
+- **Pi running its own kitchen-frontend container** (the original v1
+  design). It existed to give the Pi a local SPA for offline blips and
+  to reverse-proxy API calls to the server. The PWA solves the first job
+  more cleanly, and Tailscale + the server's nginx-proxy solve the second.
+  Keeping the duplicate added image builds, runtime config injection, and
+  a per-Pi nginx layer that drifted from the server's. Removed.
+
+- **STT routed to the server** (option C2 in the design discussion).
+  Operationally simpler — no Pi-local docker, no Pi-local cert. But it
+  loses the edge-inference claim that justifies Major-tier scope, and it
+  re-creates network dependence for the most latency-sensitive part of
+  the voice loop. Rejected.
+
+- **Auto-login via injected `/config.js`** (the kitchen-pi v1 mechanism).
+  Required baking the kitchen password into a file served to any HTTP
+  client that asked for it, with the justification that the URL was
+  behind Tailscale. Manual login at first boot is honest auth, leaves no
+  password on disk, and the Chromium kiosk profile makes it a one-time
+  cost per session anyway. Rejected.
+
+- **Per-Pi unique credentials**. Useful for per-device attribution, but
+  overkill for a single-tenant deployment. The kitchen role represents
+  the device class; per-Pi attribution can be layered on later via an
+  `X-Device-Id` header without changing the auth model. Future work.
+
+## Future hardening
+
+These aren't blockers but worth knowing:
+
+- **Tailscale-issued TLS certs.** `tailscale cert <hostname>` issues a
+  Let's Encrypt cert for a Tailscale-only hostname. Replacing the
+  self-signed cert on the server (and dropping the
+  `--ignore-certificate-errors` Chromium flag on the Pi) would close the
+  last "trust on first use" gap for HTTPS.
+
+- **Device-bound API keys** instead of shared kitchen-user creds. Each
+  Pi gets its own long-lived key on provisioning, backend has a
+  `device_keys` table mapping key → user. Reduces blast radius if a
+  single Pi's storage is compromised, and gives free per-Pi attribution.
+
+- **mTLS for the agent + rag internal channel.** The current
+  `INTERNAL_SECRET` shared header is a defensible perimeter pattern; if
+  the deployment ever moves multi-host (server split across machines),
+  mTLS or a service mesh becomes the right tool.

--- a/pi/.env.example
+++ b/pi/.env.example
@@ -1,0 +1,19 @@
+# Pi-side runtime env. Copy to .env and fill in the values for the
+# deployment target.
+
+# Tailscale MagicDNS name (or any DNS name routable over Tailscale) of the
+# voice-chef server. The Pi's Chromium kiosk opens
+# https://${SERVER_HOST}/kitchen/ — TLS terminates at the server's
+# nginx-proxy. Find this with `tailscale status` on the server.
+SERVER_HOST=voice-chef-server
+
+# faster-whisper model size for the Pi-local STT container.
+#   tiny     — fastest, weakest accuracy
+#   base     — passable
+#   small    — good accuracy (default)
+#   medium   — very good accuracy, slower
+#   large-v3 — best accuracy, heavy
+STT_MODEL=small
+
+# Force a language code (en, de, fr, ...) or leave blank for auto-detect.
+STT_LANGUAGE=

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,0 +1,144 @@
+# Kitchen-Pi
+
+The kitchen-pi is a Raspberry Pi 5 with a 7" touch display and a ReSpeaker
+microphone, running as a kiosk against the voice-chef server's kitchen UI
+over Tailscale.
+
+## What runs on the Pi
+
+| Component | Where |
+|---|---|
+| Chromium kiosk | `kitchen-point.service` (systemd) |
+| faster-whisper STT | `stt` container (`pi/docker-compose.yml`) |
+| TLS shim in front of STT | `stt-tls` container, exposes `https://localhost/stt/...` |
+| Bring-back-kiosk launcher | `pi/desktop/bring-back-kiosk.desktop` (XDG icon) |
+| Audio routing | `pi/wireplumber/51-respeaker-default.conf` |
+| Polkit rule (`systemctl restart` without sudo) | `pi/polkit/50-kitchen-kiosk.rules` |
+| Tailscale | system service, always on (provisioned outside this repo) |
+
+What does **not** run on the Pi: the kitchen frontend SPA itself. It's
+served by the server at `https://${SERVER_HOST}/kitchen/`. The PWA service
+worker handles offline shell + catalog cache; we don't need a parallel
+Pi-side deployment. See `docs/pwa.md` for the rationale and `docs/kitchen-pi.md`
+for the full module narrative.
+
+## First-time setup
+
+These steps are run once on a fresh Pi. They produce a Pi that, when
+booted, brings up Tailscale only — nothing else auto-starts until
+`start-kitchen.sh` is run.
+
+### 1. Pi OS install
+
+Use Raspberry Pi Imager to flash Pi OS Trixie (Wayland session).
+
+### 2. Tailscale
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+```
+
+Verify the Pi can reach the server:
+
+```bash
+ping -c1 $SERVER_HOST     # whatever Tailscale name your server has
+curl -k https://$SERVER_HOST/api/health
+```
+
+### 3. Docker + Compose plugin
+
+```bash
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker voice-chef
+# Log out/in once for the group change to take effect.
+```
+
+### 4. Repo + scripts
+
+The Pi only needs `pi/` and `stt/` from the repo — everything else (backend,
+agent, rag, frontend, docs) is dead weight on a kiosk device. Use a sparse
++ partial clone so only those two directories actually land on disk:
+
+```bash
+git clone --no-checkout --filter=blob:none <repo-url> /home/voice-chef/voice-chef
+cd /home/voice-chef/voice-chef
+git sparse-checkout init --cone
+git sparse-checkout set pi stt
+git checkout main
+
+cd pi
+cp .env.example .env
+$EDITOR .env                              # set SERVER_HOST
+
+sudo install -m 755 scripts/kitchen-point-start.sh /usr/local/bin/
+sudo install -m 644 systemd/kitchen-point.service /etc/systemd/system/
+sudo install -m 644 polkit/50-kitchen-kiosk.rules /etc/polkit-1/rules.d/
+mkdir -p ~/.config/wireplumber/main.lua.d
+install -m 644 wireplumber/51-respeaker-default.conf \
+    ~/.config/wireplumber/main.lua.d/
+
+# Desktop launcher (file manager may show "Execute / Mark trusted" prompt
+# the first time; click through once and the icon persists).
+install -m 755 desktop/bring-back-kiosk.desktop ~/Desktop/
+gio set ~/Desktop/bring-back-kiosk.desktop metadata::trusted true
+```
+
+### 5. Reboot
+
+```bash
+sudo reboot
+```
+
+After this, the Pi boots to a desktop. Tailscale is up. Nothing else
+runs automatically until you bring it up.
+
+## Bringing the kitchen up
+
+SSH in (or open a terminal on the Pi) and run:
+
+```bash
+cd /home/voice-chef/voice-chef/pi
+./scripts/start-kitchen.sh
+```
+
+The script:
+1. Generates a self-signed cert for the Pi-local STT TLS shim (first run only)
+2. Brings up the STT + stt-tls containers
+3. Waits for STT to respond
+4. Enables and starts `kitchen-point.service`
+
+Chromium launches into kiosk mode and lands on the login page. Authenticate
+with the kitchen-device credentials. The JWT cookie persists in
+`/home/voice-chef/.kiosk-profile` across reboots, so subsequent reboots
+relaunch the kiosk already logged in — until the cookie expires or the
+profile is wiped.
+
+## Tearing down
+
+```bash
+cd /home/voice-chef/voice-chef/pi
+./scripts/reset-kitchen.sh
+```
+
+This:
+- Disables and stops `kitchen-point.service`
+- Wipes `/home/voice-chef/.kiosk-profile` (cookie, localStorage, cache)
+- Tears down the Pi-local containers and their volumes
+- Leaves Tailscale, the repo, the `.env`, and the cert in place
+
+After this the Pi is back to "freshly-provisioned" state.
+
+## Bring-back-kiosk launcher
+
+The `bring-back-kiosk.desktop` icon on the desktop runs
+`systemctl restart kitchen-point.service` (allowed without sudo via the
+polkit rule). Useful when an operator hits Alt+F4 with greasy hands and
+needs to recover without touching a keyboard.
+
+## Why this layout
+
+For the architectural rationale — why we removed the Pi-side
+kitchen-frontend container, why STT stays on the Pi, why the Pi
+authenticates as a kitchen-role user manually rather than via auto-login —
+see `docs/kitchen-pi.md`.

--- a/pi/desktop/bring-back-kiosk.desktop
+++ b/pi/desktop/bring-back-kiosk.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Voice-Chef
+GenericName=Voice Chef kiosk relaunch
+Comment=Restart the Voice Chef kitchen kiosk
+Exec=systemctl restart kitchen-point.service
+Icon=preferences-desktop-display
+Terminal=false
+Categories=System;Utility;
+StartupNotify=false

--- a/pi/docker-compose.yml
+++ b/pi/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  # Local Whisper transcription. Pi-local STT means audio never leaves the
+  # device for the transcription step — sub-100ms latency vs. an
+  # over-network round-trip.
+  stt:
+    image: voice-chef-stt:latest
+    build:
+      context: ../stt/
+    networks:
+      - pi-network
+    environment:
+      STT_MODEL: ${STT_MODEL:-small}
+      STT_LANGUAGE: ${STT_LANGUAGE:-}
+      STT_DEVICE: cpu
+    volumes:
+      - whisper_models:/models
+    restart: unless-stopped
+
+  # Tiny TLS shim in front of STT. The kitchen SPA loads from
+  # https://${SERVER_HOST}/kitchen/ on the server — calling
+  # http://localhost:8002 from that origin would fail mixed-content checks.
+  # Exposing STT on https://localhost/ avoids that without modifying the
+  # STT image. Self-signed cert generated on the host by start-kitchen.sh
+  # (uses the host's openssl rather than installing it inside this image).
+  stt-tls:
+    image: nginx:1.28-alpine
+    networks:
+      - pi-network
+    ports:
+      - "443:443"
+    depends_on:
+      - stt
+    volumes:
+      - ./nginx/stt.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./ssl:/etc/nginx/ssl:ro
+    restart: unless-stopped
+
+volumes:
+  whisper_models:
+
+networks:
+  pi-network:
+    driver: bridge

--- a/pi/nginx/stt.conf
+++ b/pi/nginx/stt.conf
@@ -1,0 +1,34 @@
+# Pi-local TLS shim for STT.
+#
+# The kitchen SPA loads from https://${SERVER_HOST}/kitchen/ over Tailscale
+# and calls https://localhost/stt/transcribe — same scheme (HTTPS), different
+# origin. CORS is wide-open here because the only client able to reach this
+# port on the Pi is Chromium running on the same device, behind Tailscale.
+# The kitchen-pi private network is the trust boundary.
+server {
+    listen 443 ssl;
+    server_name localhost;
+
+    # Use Docker's embedded DNS for late resolution of `stt`. Without
+    # this, nginx would try to resolve `stt` at config load time and
+    # fail before the stt container is up. Mirrors the pattern used by
+    # nginx-proxy on the server side.
+    resolver 127.0.0.11 valid=30s ipv6=off;
+
+    ssl_certificate     /etc/nginx/ssl/localhost.crt;
+    ssl_certificate_key /etc/nginx/ssl/localhost.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    add_header Access-Control-Allow-Origin  "*" always;
+    add_header Access-Control-Allow-Methods "POST, GET, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "Content-Type" always;
+
+    location /stt/ {
+        if ($request_method = OPTIONS) { return 204; }
+        set $stt_upstream http://stt:8002;
+        rewrite ^/stt/(.*) /$1 break;
+        proxy_pass $stt_upstream;
+        proxy_set_header Host $host;
+        client_max_body_size 25M;   # voice clips can be sizable
+    }
+}

--- a/pi/nginx/stt.conf
+++ b/pi/nginx/stt.conf
@@ -5,6 +5,13 @@
 # origin. CORS is wide-open here because the only client able to reach this
 # port on the Pi is Chromium running on the same device, behind Tailscale.
 # The kitchen-pi private network is the trust boundary.
+
+# Self-DoS guard: a SPA bug that loops /transcribe calls (or any unexpected
+# client that does reach this port) is bounded to ~2 req/s with bursts of 4.
+# Whisper is CPU-bound on the Pi 5 — without this, a runaway loop melts the
+# kiosk. Real chef cadence is ~1 push-to-talk every few seconds, well below.
+limit_req_zone $binary_remote_addr zone=stt_rl:10m rate=2r/s;
+
 server {
     listen 443 ssl;
     server_name localhost;
@@ -25,6 +32,7 @@ server {
 
     location /stt/ {
         if ($request_method = OPTIONS) { return 204; }
+        limit_req zone=stt_rl burst=4 nodelay;
         set $stt_upstream http://stt:8002;
         rewrite ^/stt/(.*) /$1 break;
         proxy_pass $stt_upstream;

--- a/pi/polkit/50-kitchen-kiosk.rules
+++ b/pi/polkit/50-kitchen-kiosk.rules
@@ -1,0 +1,18 @@
+// Allow the voice-chef user to manage kitchen-point.service without a
+// password prompt. Scoped narrowly: only this user, only this service —
+// other systemd actions still require normal authentication.
+//
+// Effect: the desktop launcher (pi/desktop/bring-back-kiosk.desktop) can
+// invoke `systemctl restart kitchen-point.service` directly without sudo
+// or pkexec, giving the kitchen user a one-click recovery after Alt+F4.
+//
+// Install: copy to /etc/polkit-1/rules.d/50-kitchen-kiosk.rules, then
+// reload polkit (`sudo systemctl restart polkit`) or just reboot.
+
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.systemd1.manage-units" &&
+        action.lookup("unit") == "kitchen-point.service" &&
+        subject.user == "voice-chef") {
+        return polkit.Result.YES;
+    }
+});

--- a/pi/scripts/kitchen-point-start.sh
+++ b/pi/scripts/kitchen-point-start.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Voice Chef — Kitchen Point kiosk launcher.
+#
+# Invoked by /etc/systemd/system/kitchen-point.service. The systemd unit is
+# enabled by start-kitchen.sh at setup and disabled by reset-kitchen.sh.
+# While enabled, this script runs:
+#   - on initial start (`systemctl start kitchen-point.service`)
+#   - on every reboot (because the unit is in graphical.target)
+#
+# Containers (STT + stt-tls) come up via their `restart: unless-stopped`
+# policy on the same boot — we don't bring them up here, that's
+# start-kitchen.sh's job.
+
+set -euo pipefail
+
+ENV_FILE="/home/voice-chef/voice-chef/pi/.env"
+[ -f "$ENV_FILE" ] && source "$ENV_FILE"
+
+KIOSK_URL="https://${SERVER_HOST}/kitchen/?kiosk=1"
+KIOSK_PROFILE_DIR="/home/voice-chef/.kiosk-profile"
+
+echo "[kitchen-point] $(date -Iseconds) — launching Chromium kiosk → ${KIOSK_URL}"
+
+# --ignore-certificate-errors accepts both the server's self-signed cert
+# (perimeter HTTPS via nginx-proxy) and the Pi-local self-signed cert
+# (https://localhost/stt/...).
+exec chromium \
+    --kiosk \
+    --ignore-certificate-errors \
+    --ozone-platform=wayland \
+    --force-device-scale-factor=1.5 \
+    --no-first-run \
+    --noerrdialogs \
+    --disable-restore-session-state \
+    --disable-features=TranslateUI \
+    --autoplay-policy=no-user-gesture-required \
+    --use-fake-ui-for-media-stream \
+    --password-store=basic \
+    --user-data-dir="$KIOSK_PROFILE_DIR" \
+    --start-maximized \
+    "$KIOSK_URL"

--- a/pi/scripts/kitchen-point-start.sh
+++ b/pi/scripts/kitchen-point-start.sh
@@ -19,6 +19,21 @@ ENV_FILE="/home/voice-chef/voice-chef/pi/.env"
 KIOSK_URL="https://${SERVER_HOST}/kitchen/?kiosk=1"
 KIOSK_PROFILE_DIR="/home/voice-chef/.kiosk-profile"
 
+# Wait for the server to be reachable before launching Chromium.
+# Without this, on a fresh boot Chromium can race ahead of Tailscale/network
+# readiness — the SPA's first /api/auth/me call fails with a network error
+# (treated identically to 401 by getCurrentUser), the SPA redirects to
+# /login, and the login page sees a valid cookie and bounces to office root.
+# Net effect: kiosk lands on the office start page instead of /kitchen/.
+echo "[kitchen-point] $(date -Iseconds) — waiting for ${SERVER_HOST} to respond"
+for i in $(seq 1 60); do
+    if curl -kfsS --max-time 3 "https://${SERVER_HOST}/kitchen/" >/dev/null 2>&1; then
+        echo "[kitchen-point] server reachable after ${i}×2s"
+        break
+    fi
+    sleep 2
+done
+
 echo "[kitchen-point] $(date -Iseconds) — launching Chromium kiosk → ${KIOSK_URL}"
 
 # --ignore-certificate-errors accepts both the server's self-signed cert

--- a/pi/scripts/reset-kitchen.sh
+++ b/pi/scripts/reset-kitchen.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Voice Chef — Pi teardown.
+#
+# Returns the Pi to a clean state — only Tailscale will be running after this.
+# Run manually whenever you want to start fresh from the login screen.
+#
+# Wipes:
+#   - The Chromium kiosk profile (cookie, localStorage, IndexedDB, cache)
+#   - The local containers (STT + stt-tls) and their volumes
+#   - The auto-start of the kiosk systemd unit
+#
+# Does NOT touch:
+#   - Tailscale (its own systemd unit, always-on)
+#   - The repo, .env, ssl/ certificates, or any committed config
+#
+# After this script, the Pi is back to "freshly-provisioned" state and
+# ready for start-kitchen.sh to run again.
+
+set -euo pipefail
+
+KIOSK_PROFILE_DIR="/home/voice-chef/.kiosk-profile"
+COMPOSE_DIR="/home/voice-chef/voice-chef/pi"
+
+echo "[reset-kitchen] disabling kiosk autostart + stopping it"
+sudo systemctl disable --now kitchen-point.service 2>/dev/null || true
+
+# In case Chromium is still running for any reason.
+pkill chromium 2>/dev/null || true
+
+echo "[reset-kitchen] wiping kiosk profile (${KIOSK_PROFILE_DIR})"
+rm -rf "$KIOSK_PROFILE_DIR"
+
+echo "[reset-kitchen] tearing down Pi-local containers"
+cd "$COMPOSE_DIR"
+docker compose down
+
+cat <<'EOF'
+
+[reset-kitchen] done.
+  - Kiosk autostart disabled; reboot now will leave the Pi at a desktop.
+  - Run start-kitchen.sh to bring everything back up for a new session.
+EOF

--- a/pi/scripts/reset-kitchen.sh
+++ b/pi/scripts/reset-kitchen.sh
@@ -6,7 +6,10 @@
 #
 # Wipes:
 #   - The Chromium kiosk profile (cookie, localStorage, IndexedDB, cache)
-#   - The local containers (STT + stt-tls) and their volumes
+#   - The local containers (STT + stt-tls); the named volumes (whisper
+#     model cache) are intentionally kept so the next start-kitchen.sh
+#     doesn't have to re-download ~250 MB. To wipe them too, follow up
+#     with `docker compose down --volumes` from pi/.
 #   - The auto-start of the kiosk systemd unit
 #
 # Does NOT touch:

--- a/pi/scripts/start-kitchen.sh
+++ b/pi/scripts/start-kitchen.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Voice Chef — Pi setup / session bootstrap.
+#
+# Run once after SSH-ing into a fresh Pi to bring everything up:
+#   1. Generate the self-signed cert for the Pi-local STT TLS shim if missing
+#   2. Bring up local containers (STT + stt-tls) via docker compose
+#   3. Wait for STT to respond
+#   4. Enable + start the kiosk systemd unit
+#
+# After this runs once:
+#   - The kiosk launches Chromium against the server's kitchen URL
+#   - The login page renders; authenticate with the kitchen-device credentials
+#   - The JWT cookie persists in --user-data-dir across reboots
+#   - On reboot, containers auto-restart (unless-stopped) and systemd brings
+#     the kiosk back automatically; no human interaction needed
+#
+# To tear everything back to a clean state, run reset-kitchen.sh.
+
+set -euo pipefail
+
+REPO_DIR="/home/voice-chef/voice-chef"
+COMPOSE_DIR="${REPO_DIR}/pi"
+ENV_FILE="${COMPOSE_DIR}/.env"
+CERT_DIR="${COMPOSE_DIR}/ssl"
+HEALTH_TIMEOUT=60
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "[start-kitchen] ERROR: ${ENV_FILE} missing." >&2
+    echo "[start-kitchen] Copy ${COMPOSE_DIR}/.env.example to .env and edit SERVER_HOST." >&2
+    exit 1
+fi
+
+# 1. Self-signed cert for the Pi-local STT TLS shim.
+# The Pi has openssl by default; generating on the host is simpler than
+# pulling openssl into the nginx:alpine image at runtime.
+if [ ! -f "${CERT_DIR}/localhost.crt" ]; then
+    mkdir -p "$CERT_DIR"
+    openssl req -x509 -nodes -newkey rsa:2048 \
+        -keyout "${CERT_DIR}/localhost.key" \
+        -out   "${CERT_DIR}/localhost.crt" \
+        -days 3650 \
+        -subj "/CN=localhost" \
+        -addext "subjectAltName=DNS:localhost"
+    chmod 600 "${CERT_DIR}/localhost.key"
+    echo "[start-kitchen] generated self-signed cert for Pi-local STT"
+fi
+
+# 2. Bring up Pi-local containers.
+echo "[start-kitchen] starting Pi-local stack (STT + TLS shim)"
+cd "$COMPOSE_DIR"
+docker compose up -d
+
+# 3. Wait for STT to be reachable through the TLS shim.
+echo "[start-kitchen] waiting up to ${HEALTH_TIMEOUT}s for STT"
+for i in $(seq 1 "$HEALTH_TIMEOUT"); do
+    if curl -fks --max-time 2 https://localhost/stt/health > /dev/null 2>&1; then
+        echo "[start-kitchen] STT healthy after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+if ! curl -fks --max-time 2 https://localhost/stt/health > /dev/null 2>&1; then
+    echo "[start-kitchen] WARNING: STT did not become healthy in ${HEALTH_TIMEOUT}s" >&2
+    echo "[start-kitchen] Continuing anyway — kiosk will launch but voice may be unavailable" >&2
+fi
+
+# 4. Enable + start the kiosk systemd unit. `enable --now` does both:
+# starts immediately AND wires WantedBy=graphical.target so reboots
+# bring it back. reset-kitchen.sh undoes this.
+echo "[start-kitchen] enabling + starting kitchen-point.service"
+sudo systemctl enable --now kitchen-point.service
+
+cat <<'EOF'
+
+[start-kitchen] done.
+  - Chromium kiosk should be launching against the server's kitchen URL.
+  - On the login screen, authenticate with the kitchen-device credentials.
+  - The cookie persists across reboots in /home/voice-chef/.kiosk-profile.
+  - Run reset-kitchen.sh to wipe state and disable autostart.
+EOF

--- a/pi/systemd/kitchen-point.service
+++ b/pi/systemd/kitchen-point.service
@@ -13,11 +13,11 @@ Restart=on-failure
 RestartSec=10
 TimeoutStartSec=120
 
-# Wayland session for kiosk Chromium.
-# UID 1000 is the default for the first user (voice-chef) on a fresh
-# Pi OS install. If yours differs, adjust XDG_RUNTIME_DIR=/run/user/<uid>.
+# Wayland session for kiosk Chromium. %U resolves to the service user's
+# numeric UID at unit start, so XDG_RUNTIME_DIR points at the right
+# /run/user/<uid> directory regardless of how the user was provisioned.
 Environment=WAYLAND_DISPLAY=wayland-0
-Environment=XDG_RUNTIME_DIR=/run/user/1000
+Environment=XDG_RUNTIME_DIR=/run/user/%U
 
 [Install]
 WantedBy=graphical.target

--- a/pi/systemd/kitchen-point.service
+++ b/pi/systemd/kitchen-point.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Voice Chef — Kitchen Point
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+User=voice-chef
+Group=voice-chef
+ExecStart=/usr/local/bin/kitchen-point-start.sh
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=120
+
+# Wayland session for kiosk Chromium.
+# UID 1000 is the default for the first user (voice-chef) on a fresh
+# Pi OS install. If yours differs, adjust XDG_RUNTIME_DIR=/run/user/<uid>.
+Environment=WAYLAND_DISPLAY=wayland-0
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+
+[Install]
+WantedBy=graphical.target

--- a/pi/wireplumber/51-respeaker-default.conf
+++ b/pi/wireplumber/51-respeaker-default.conf
@@ -1,0 +1,28 @@
+# Pin the Seeed reSpeaker XVF3800 4-Mic Array as the default audio source
+# in PipeWire/WirePlumber.
+#
+# Higher priority.* values cause WirePlumber to auto-select this device
+# as the default capture source whenever it is present, including across
+# reboots and after package updates.
+#
+# The regex matches the node.name PipeWire assigns to Seeed-branded
+# reSpeaker XVF3800 boards. The numeric serial in the middle of the actual
+# node name varies between physical units, so the pattern uses a prefix
+# match. Example node.name on a real board:
+#   alsa_input.usb-Seeed_Studio_reSpeaker_XVF3800_4-Mic_Array_<serial>-00.analog-stereo
+
+monitor.alsa.rules = [
+    {
+        matches = [
+            {
+                node.name = "~alsa_input.usb-Seeed_Studio_reSpeaker_XVF3800.*"
+            }
+        ]
+        actions = {
+            update-props = {
+                priority.driver  = 3000
+                priority.session = 3000
+            }
+        }
+    }
+]


### PR DESCRIPTION
## What this PR does

Replaces the Pi-side kitchen-frontend container with a thin-client + edge
inference layout. Supersedes PR #205.

The Pi now runs:
- **Chromium kiosk** against `https://${SERVER_HOST}/kitchen/` over Tailscale
- **STT (faster-whisper)** locally for sub-100ms voice transcription
- **A tiny nginx TLS shim** in front of STT (so the HTTPS-loaded SPA can
  call it on `https://localhost/stt/...` without mixed-content errors)

What it no longer runs: a duplicate copy of the kitchen-frontend SPA
container.

## Why

The Pi previously hosted its own kitchen-frontend image — a near-duplicate
build of the server's SPA, with its own nginx upstream config and runtime
config injection. That duplication existed to give the Pi local SPA assets
during network blips and to reverse-proxy API calls over Tailscale. Two
recent changes make it unnecessary:

- **PR #225 (PWA)** — the kitchen frontend is now a PWA. Service worker
  handles offline shell + catalog cache, replacing the Pi-local nginx's
  job during network blips.
- **PR #216 (perimeter TLS)** — the server's nginx-proxy is now the only
  externally-bound port on the server. The Pi's old setup tried to reach
  raw `:8000` / `:8001` ports that no longer exist.

Together: the architectural justification for the duplicate container
evaporated. This PR is the cleanup.

## Authentication

Plain JWT cookie auth, the same flow a human uses in the office UI. On
fresh boot, the kiosk lands on the server's `/login` page. Operator types
the kitchen-device credentials once. The cookie persists in
`/home/voice-chef/.kiosk-profile` across reboots. `reset-kitchen.sh`
wipes the profile to return to a fresh-login state.

No auto-login feature, no kitchen password baked into a file served
to any HTTP client. The kitchen-pi v1 design did this; we deliberately
moved away from it (rationale in `docs/kitchen-pi.md`).

## Lean Pi-side checkout

The provisioning steps in `pi/README.md` use a sparse + partial git clone
(`--filter=blob:none` + `sparse-checkout`) so only `pi/` and `stt/` land
on the Pi. Backend, agent, rag, and frontend source never touch the
kiosk device.

## Files

- **New:** `pi/docker-compose.yml`, `pi/nginx/stt.conf`,
  `pi/scripts/{start,reset}-kitchen.sh`, `pi/.env.example`,
  `pi/README.md`, `docs/kitchen-pi.md`
- **Carried over from kitchen-pi (unchanged):** systemd unit, polkit rule,
  desktop launcher, wireplumber audio config
- **Slimmed:** `pi/scripts/kitchen-point-start.sh` — now just the
  Chromium-launch step, no docker-compose orchestration

## Migration / cutover

1. On the server: nothing to change; this PR doesn't touch the server side
2. On the Pi: stop the existing `kitchen-frontend` container if running
   (`docker compose -f /old-pi/docker-compose.yml down`)
3. Sparse-clone the repo as documented in the new `pi/README.md`
4. Run `./pi/scripts/start-kitchen.sh`

## Test plan

- [ ] Build STT image on the Pi (~5–10 min on a Pi 5)
- [ ] STT serves `/health` over `https://localhost/stt/health` with the
      Pi-local self-signed cert
- [ ] Chromium kiosk opens to the server's login page
- [ ] Login + render kitchen UI
- [ ] Voice query end-to-end (mic → Pi-local STT → server agent → render)
- [ ] Reboot → kiosk relaunches automatically with cookie still valid
- [ ] `reset-kitchen.sh` returns the Pi to a state where only Tailscale
      runs on boot

## Known issue (separate track)

While testing this PR on real hardware we hit a pre-existing auth bug
that's unrelated to the Pi rework — kitchen-pi user manually logs in,
the kiosk works correctly, but on the next reboot or
`systemctl restart kitchen-point.service` the kiosk lands on office root
instead of `/kitchen/`. Root cause: the backend's `/api/auth/login`
sets the JWT cookie without `max_age`/`expires`, making it a session
cookie that Chromium drops every time the browser process exits. Office
doesn't hit this because it uses localStorage + Bearer; kitchen relies
only on the cookie.

Tracked as #243. One-line backend fix (add `max_age` to `set_cookie`)
resolves it without touching this PR.

The Pi-side launcher in this PR also waits for server reachability
before launching Chromium — useful for cold boots but doesn't address
the cookie-lifetime bug above.

## Out of scope

- Auto-login at the SPA level (rejected; rationale in `docs/kitchen-pi.md`)
- Per-Pi unique credentials (kitchen role represents the device class for
  now; per-Pi attribution can be added via X-Device-Id headers later)
- Pre-built STT image from a registry (Pi builds locally for now; switching
  to a registry-pulled image is a small follow-up)
- Tailscale-issued TLS for the server (would let us drop
  `--ignore-certificate-errors` on the kiosk)

PR #205 (kitchen-pi v1) stays open for now as a reference; can be closed
when this lands.
