### PR TITLE
Removed obsolete buttons from frontend

### DIFF
--- a/frontend/office/src/components/ingredients/IngredientList.tsx
+++ b/frontend/office/src/components/ingredients/IngredientList.tsx
@@ -51,7 +51,7 @@ export function IngredientsList() {
             setPage(0);
           }}
         />
-        <Input
+        {/* <Input
           placeholder="Filter by source (e.g. standard, custom)..."
           className="max-w-sm"
           value={sourceFilter}
@@ -59,7 +59,7 @@ export function IngredientsList() {
             setSourceFilter(e.target.value);
             setPage(0);
           }}
-        />
+        /> */}
 
         {!isInitialLoading && ingredientPage && (
           <span className="text-sm text-muted-foreground">
@@ -75,12 +75,12 @@ export function IngredientsList() {
           >
             {viewMode === 'grid' ? 'List view' : 'Grid view'}
           </Button>
-          <Button variant="outline" type="button">
+          {/* <Button variant="outline" type="button">
             Import
           </Button>
           <Button variant="outline" type="button">
             Export
-          </Button>
+          </Button> */}
         </div>
       </div>
 

--- a/frontend/office/src/components/ingredients/IngredientList.tsx
+++ b/frontend/office/src/components/ingredients/IngredientList.tsx
@@ -20,18 +20,18 @@ function IngredientSkeleton() {
 }
 
 export function IngredientsList() {
-  const [sourceFilter, setSourceFilter] = useState('');
+  // const [sourceFilter, setSourceFilter] = useState('');
   const [nameFilter, setNameFilter] = useState('');
   const [page, setPage] = useState(0);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
 
   const offset = page * PAGE_SIZE;
   const normalizedNameFilter = nameFilter.trim();
-  const normalizedSourceFilter = sourceFilter.trim();
+  // const normalizedSourceFilter = sourceFilter.trim();
 
   const { data: ingredientPage, isLoading, isError, error } = useIngredients({
     ...(normalizedNameFilter ? { search: normalizedNameFilter } : {}),
-    ...(normalizedSourceFilter ? { source: normalizedSourceFilter } : {}),
+    // ...(normalizedSourceFilter ? { source: normalizedSourceFilter } : {}),
     offset,
     limit: PAGE_SIZE,
   });

--- a/frontend/office/src/components/login-form.tsx
+++ b/frontend/office/src/components/login-form.tsx
@@ -103,9 +103,9 @@ export function LoginForm({
                 <Button type="submit" disabled={isSubmitting}>
                   {isSubmitting ? "Signing in..." : "Login"}
                 </Button>
-                <Button variant="outline" type="button">
+                {/* <Button variant="outline" type="button">
                   Login with Google
-                </Button>
+                </Button> */}
                 <FieldDescription className="text-center">
                   Don&apos;t have an account? <Link to="/signup">Sign up</Link>
                 </FieldDescription>

--- a/frontend/office/src/components/recipes/RecipeList.tsx
+++ b/frontend/office/src/components/recipes/RecipeList.tsx
@@ -133,12 +133,12 @@ export function RecipeList() {
           >
             {viewMode === 'grid' ? 'List view' : 'Grid view'}
           </Button>
-          <Button variant="outline" type="button">
+          {/* <Button variant="outline" type="button">
             Import
           </Button>
           <Button variant="outline" type="button">
             Export
-          </Button>
+          </Button> */}
         </div>
       </div>
 

--- a/frontend/office/src/components/signup-form.tsx
+++ b/frontend/office/src/components/signup-form.tsx
@@ -160,7 +160,7 @@ export function SignupForm({
                   Create Account
                 </Button>
               </Field>
-              <FieldSeparator className="*:data-[slot=field-separator-content]:bg-card">
+              {/* <FieldSeparator className="*:data-[slot=field-separator-content]:bg-card">
                 Or continue with
               </FieldSeparator>
               <Field className="grid grid-cols-3 gap-4">
@@ -191,7 +191,7 @@ export function SignupForm({
                   </svg>
                   <span className="sr-only">Sign up with Meta</span>
                 </Button>
-              </Field>
+              </Field> */}
               <FieldDescription className="text-center">
                 Already have an account? <a href="/login">Sign in</a>
               </FieldDescription>

--- a/frontend/office/src/components/signup-form.tsx
+++ b/frontend/office/src/components/signup-form.tsx
@@ -7,7 +7,7 @@ import {
   FieldDescription,
   FieldGroup,
   FieldLabel,
-  FieldSeparator,
+  // FieldSeparator,
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { toast } from "sonner"

--- a/frontend/office/src/pages/CreateRecipePage.tsx
+++ b/frontend/office/src/pages/CreateRecipePage.tsx
@@ -227,9 +227,9 @@ export function CreateRecipePage() {
               <Button
                 variant="outline"
                 onClick={addIngredientRow}
-                className="border-black text-lg text-green-900 font-bold px-3 py-1 h-auto"
+                className="border-black text-sm text-green-900 font-bold px-3 py-1 h-auto"
               >
-                + Add Row
+                + Add Ingredient
               </Button>
             </div>
           </Section>

--- a/frontend/office/src/pages/RecipeDetailPage.tsx
+++ b/frontend/office/src/pages/RecipeDetailPage.tsx
@@ -186,12 +186,12 @@ export function RecipeDetailPage() {
             >
               Change status
             </Button>
-            <Button size="lg" onClick={() => alert('Edit recipe functionality coming soon!')}>
+            {/* <Button size="lg" onClick={() => alert('Edit recipe functionality coming soon!')}>
               Edit
             </Button>
             <Button size="lg" variant="outline" onClick={() => alert('Duplicate recipe functionality coming soon!')}>
               Duplicate
-            </Button>
+            </Button> */}
             <Button
               size="lg"
               variant="destructive"


### PR DESCRIPTION
This pull request primarily comments out or removes several UI elements related to import/export features and third-party authentication, likely to simplify the interface or temporarily disable unfinished functionality. Additionally, there are minor text and style adjustments for improved clarity.

**UI Feature Disabling and Cleanup:**

* Commented out the "Import" and "Export" buttons in both the `RecipeList` and `IngredientList` components to hide these actions from the interface. [[1]](diffhunk://#diff-70206b325855b536f8b4796ea437f4d6d373e025cc941b95bbda1b11a6a0d34bL136-R141) [[2]](diffhunk://#diff-a3fa6afa866809431ac97fe26a90be306080799ab4c807b7a275f9213525e114L78-R83)
* Commented out the Google login button in the `LoginForm` and third-party signup options in the `SignupForm`, removing external authentication choices from the forms. [[1]](diffhunk://#diff-09fd8bee84dec292993fba25151e504582ce153b7bd55e51f35784162d73f2ceL106-R108) [[2]](diffhunk://#diff-bf25da9020050b578809e7eb68983f550c397eb7700395a439c68df5458dd931L163-R163) [[3]](diffhunk://#diff-bf25da9020050b578809e7eb68983f550c397eb7700395a439c68df5458dd931L194-R194)
* Commented out the source filter input in the `IngredientList`, disabling filtering by ingredient source for now.
* Commented out the "Edit" and "Duplicate" recipe buttons in the `RecipeDetailPage`, hiding editing and duplication actions.

**Minor UI Improvements:**

* Updated the "Add Row" button in `CreateRecipePage` to read "+ Add Ingredient" and reduced its font size for better clarity and consistency.
* Removed the unused `FieldSeparator` import from `signup-form.tsx`.