### PR TITLE
97 file upload feature for recipe pictures

### DIFF
--- a/frontend/kitchen/nginx.conf
+++ b/frontend/kitchen/nginx.conf
@@ -2,6 +2,8 @@ server {
     listen 80;
     listen [::]:80;
     server_name _;
+    return 308 https://$host$request_uri;
+    
     client_max_body_size 100M;
 
     root /usr/share/nginx/html;

--- a/frontend/kitchen/nginx.conf
+++ b/frontend/kitchen/nginx.conf
@@ -2,6 +2,7 @@ server {
     listen 80;
     listen [::]:80;
     server_name _;
+    client_max_body_size 100M;
 
     root /usr/share/nginx/html;
     index index.html;

--- a/frontend/kitchen/nginx.conf
+++ b/frontend/kitchen/nginx.conf
@@ -2,7 +2,6 @@ server {
     listen 80;
     listen [::]:80;
     server_name _;
-    return 308 https://$host$request_uri;
     
     client_max_body_size 100M;
 

--- a/frontend/office/nginx.conf
+++ b/frontend/office/nginx.conf
@@ -2,6 +2,8 @@ server {
     listen 80;
     listen [::]:80;
     server_name _;
+    return 308 https://$host$request_uri;
+    
     client_max_body_size 100M;
 
     root /usr/share/nginx/html;

--- a/frontend/office/nginx.conf
+++ b/frontend/office/nginx.conf
@@ -2,6 +2,7 @@ server {
     listen 80;
     listen [::]:80;
     server_name _;
+    client_max_body_size 100M;
 
     root /usr/share/nginx/html;
     index index.html;

--- a/frontend/office/nginx.conf
+++ b/frontend/office/nginx.conf
@@ -2,7 +2,6 @@ server {
     listen 80;
     listen [::]:80;
     server_name _;
-    return 308 https://$host$request_uri;
     
     client_max_body_size 100M;
 

--- a/frontend/office/src/pages/FilesPage.tsx
+++ b/frontend/office/src/pages/FilesPage.tsx
@@ -94,15 +94,7 @@ export function FilesPage() {
       setUploadBytesLoaded(0);
       setUploadProgress(0);
 
-      uploadMutation.mutate({
-        file,
-        onProgress: (progressEvent) => {
-          if (!progressEvent.total) return;
-          setUploadBytesLoaded(progressEvent.loaded);
-          setUploadBytesTotal(progressEvent.total);
-          setUploadProgress(Math.round((progressEvent.loaded / progressEvent.total) * 100));
-        },
-      });
+      // wait for validation before uploading (progress handler attached below)
     }
     if (!file) return;
 
@@ -132,7 +124,17 @@ export function FilesPage() {
 
     setUploadError(null);
     validatePDF(file)
-      .then(() => uploadMutation.mutate(file))
+      .then(() =>
+        uploadMutation.mutate({
+          file,
+          onProgress: (progressEvent: any) => {
+            if (!progressEvent.total) return;
+            setUploadBytesLoaded(progressEvent.loaded);
+            setUploadBytesTotal(progressEvent.total);
+            setUploadProgress(Math.round((progressEvent.loaded / progressEvent.total) * 100));
+          },
+        })
+      )
       .catch((err: any) => setUploadError(err?.message || String(err)))
       .finally(() => {
         if (fileInputRef.current) fileInputRef.current.value = '';

--- a/frontend/office/src/pages/FilesPage.tsx
+++ b/frontend/office/src/pages/FilesPage.tsx
@@ -48,9 +48,39 @@ export function FilesPage() {
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) {
-      uploadMutation.mutate(file);
-    }
+    if (!file) return;
+
+    const validatePDF = async (f: File) => {
+      const MAX_SIZE_MB = 100;
+      const MAX_SIZE = MAX_SIZE_MB * 1024 * 1024; // 100MB
+      const allowedType = 'application/pdf';
+
+      if (f.size === 0) throw new Error('File is empty');
+      if (f.size > MAX_SIZE) throw new Error(`File size exceeds the limit of ${MAX_SIZE_MB}MB`);
+
+      // MIME type may be absent in some browsers; check both type and extension
+      const nameLower = f.name.toLowerCase();
+      if (f.type !== allowedType && !nameLower.endsWith('.pdf')) {
+        throw new Error('Only PDF files are allowed');
+      }
+
+      // Read first bytes to verify PDF header (%PDF-)
+      const headerSize = 5;
+      const buf = await f.slice(0, headerSize).arrayBuffer();
+      const bytes = new Uint8Array(buf);
+      const header = String.fromCharCode(...bytes);
+      if (!header.startsWith('%PDF-')) {
+        throw new Error('Invalid or corrupted PDF file');
+      }
+    };
+
+    setUploadError(null);
+    validatePDF(file)
+      .then(() => uploadMutation.mutate(file))
+      .catch((err: any) => setUploadError(err?.message || String(err)))
+      .finally(() => {
+        if (fileInputRef.current) fileInputRef.current.value = '';
+      });
   };
 
   const handleDelete = (filename: string) => {

--- a/frontend/office/src/pages/RecipeDetailPage.tsx
+++ b/frontend/office/src/pages/RecipeDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { 
   useDeleteRecipe, 
@@ -14,7 +14,6 @@ import { formatDatetime } from '../components/Format-Datetime.tsx';
 import { DetailRow } from '../components/Detail-row';
 import { Grid } from '../components/Grid';
 import { cn } from '@/lib/utils';
-import { useRef } from 'react';
 
 const STATUS_STYLES: Record<string, string> = {
   draft: 'bg-yellow-100 text-yellow-800',
@@ -38,6 +37,7 @@ export function RecipeDetailPage() {
   const uploadPhoto = useUploadRecipePicture();
   const deletePhoto = useDeleteRecipePicture();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   // Navigate away immediately after successful deletion
   useEffect(() => {
@@ -76,12 +76,83 @@ export function RecipeDetailPage() {
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (file && recipe) {
-      uploadPhoto.mutate({ id: recipe.id, file });
-    }
-    // Reset input so the same file can be selected again
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
+    if (!file) return;
+
+    const validateImage = (f: File) => {
+      const ALLOWED_TYPES = ['image/jpeg', 'image/png'];
+      const MAX_SIZE_MB = 1;
+      const MAX_SIZE = MAX_SIZE_MB * 1024 * 1024; // 10MB
+      const MIN_DIM = 200;
+      const MAX_DIM = 6000;
+
+      return new Promise<void>((resolve, reject) => {
+        if (!ALLOWED_TYPES.includes(f.type)) {
+          reject('Only JPG, JPEG and PNG images are allowed');
+          return;
+        }
+
+        if (f.size === 0) {
+          reject('File is empty');
+          return;
+        }
+
+        if (f.size > MAX_SIZE) {
+          reject(`File size exceeds the limit of ${MAX_SIZE_MB}MB`);
+          return;
+        }
+
+        const url = URL.createObjectURL(f);
+        const img = new Image();
+        img.onload = () => {
+          const { width, height } = img;
+          URL.revokeObjectURL(url);
+          if (width < MIN_DIM || height < MIN_DIM) {
+            reject(`Image dimensions too small. Minimum is ${MIN_DIM}x${MIN_DIM}px`);
+            return;
+          }
+          if (width > MAX_DIM || height > MAX_DIM) {
+            reject(`Image dimensions too large. Maximum is ${MAX_DIM}x${MAX_DIM}px`);
+            return;
+          }
+          // simple format verification by attempting to draw to canvas (detects some corruptions)
+          try {
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+            const ctx = canvas.getContext('2d');
+            if (!ctx) {
+              // if no context, still accept (uncommon)
+              resolve();
+              return;
+            }
+            ctx.drawImage(img, 0, 0);
+            // attempt to read a few pixels
+            ctx.getImageData(0, 0, 1, 1);
+            resolve();
+          } catch (err) {
+            reject('Invalid or corrupted image file');
+          }
+        };
+        img.onerror = () => {
+          URL.revokeObjectURL(url);
+          reject('Invalid or corrupted image file');
+        };
+        img.src = url;
+      });
+    };
+
+    setUploadError(null);
+    if (recipe) {
+      validateImage(file)
+        .then(() => {
+          uploadPhoto.mutate({ id: recipe.id, file });
+        })
+        .catch((err) => {
+          setUploadError(typeof err === 'string' ? err : 'Invalid image file');
+        })
+        .finally(() => {
+          if (fileInputRef.current) fileInputRef.current.value = '';
+        });
     }
   };
 
@@ -163,6 +234,11 @@ export function RecipeDetailPage() {
           className="hidden"
           disabled={uploadPhoto.isPending}
         />
+        {uploadError && (
+          <div className="mt-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+            {uploadError}
+          </div>
+        )}
         <div className="flex items-center gap-3 flex-wrap">
           <InlineEditableRecipeText
             recipeId={recipe.id}

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -10,7 +10,6 @@ server {
     listen [::]:80;
     server_name _;
     client_max_body_size 100M;
-    return 308 https://$host$request_uri;
 }
 
 server {

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -9,6 +9,7 @@ server {
     listen 80;
     listen [::]:80;
     server_name _;
+    client_max_body_size 100M;
     return 308 https://$host$request_uri;
 }
 
@@ -16,6 +17,7 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
     server_name _;
+    client_max_body_size 100M;
 
     # ── SSL ────────────────────────────────────────────────────
     ssl_certificate     /etc/nginx/ssl/nginx.crt;

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -9,7 +9,6 @@ server {
     listen 80;
     listen [::]:80;
     server_name _;
-    client_max_body_size 100M;
     return 308 https://$host$request_uri;
 }
 

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -10,6 +10,7 @@ server {
     listen [::]:80;
     server_name _;
     client_max_body_size 100M;
+    return 308 https://$host$request_uri;
 }
 
 server {


### PR DESCRIPTION
Validations added on front end:

RECIPE IMAGES
Type - only  JPEG, PNG allowed
Size - max 10mb
Dimensions: minimum of 200x200px, maximum of 6000x6000px
Format validation to ensure its a true file provided (not corrupted file)

PDF FILES
Type - only PDF allowed
Size - max 100mb
Format validation to ensure its a true file provided (not corrupted file)

nginx conf  `client_max_body_size 100M;` are added to all nginx.conf files
