### PR TITLE
[BUG] ingredient-list-disappears-on-saving-description-instructions; fix applied

### DIFF
--- a/frontend/office/src/hooks/useRecipes.ts
+++ b/frontend/office/src/hooks/useRecipes.ts
@@ -106,7 +106,10 @@ export function useUpdateRecipe() {
       return data;
     },
     onSuccess: (updatedRecipe) => {
-      queryClient.setQueryData([RECIPES_KEY, updatedRecipe.id], updatedRecipe);
+      queryClient.setQueryData([RECIPES_KEY, updatedRecipe.id], (oldData: any) => ({
+        ...oldData,
+        ...updatedRecipe,
+      }));
       queryClient.invalidateQueries({
         queryKey: [RECIPES_KEY],
         predicate: (query) => typeof query.queryKey[1] === 'object',


### PR DESCRIPTION
This pull request makes a targeted improvement to the way recipe updates are handled in the `useUpdateRecipe` hook. Instead of replacing the entire cached recipe object with the updated one, the code now merges the updated fields into the existing cached data, ensuring that any unchanged fields are preserved.

- Improved cache update logic in `useUpdateRecipe`: The `onSuccess` handler now merges the updated recipe data into the existing cached recipe, rather than replacing it entirely. This helps prevent loss of any fields that might not be included in the update response. (`frontend/office/src/hooks/useRecipes.ts`)