### PR TITLE
[FE] add ability-to-update-all-recipe-fields-via-front-end

### DIFF
--- a/backend/app/schemas/recipe.py
+++ b/backend/app/schemas/recipe.py
@@ -74,6 +74,8 @@ class RecipeUpdate(SQLModel):
     name: str | None = Field(default=None, min_length=1)
     description: str | None = None
     instructions: str | None = None
+    preparation_time_minutes: int | None = Field(default=None)
+    cooking_time_minutes: int | None = Field(default=None)
 
     status: str | None = None
     yield_mode: str | None = None

--- a/frontend/office/src/components/recipes/InlineEditableRecipeText.tsx
+++ b/frontend/office/src/components/recipes/InlineEditableRecipeText.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import { useUpdateRecipe } from '@/hooks/useRecipes';
 import type { RecipeDetail } from '@/types/recipe';
 
-type EditableRecipeField = 'name' | 'description' | 'instructions';
+type EditableRecipeField = 'name' | 'description' | 'instructions' | 'preparation_time_minutes' | 'cooking_time_minutes' | 'portion_size_grams' | 'portions_count_resolved' | 'total_raw_weight_grams' | 'total_cooked_weight_grams' | 'yield_mode';
 
 export function InlineEditableRecipeText({
   recipeId,
@@ -16,23 +16,25 @@ export function InlineEditableRecipeText({
   multiline = false,
   className,
   displayClassName,
+  type = 'text',
 }: {
   recipeId: string;
   field: EditableRecipeField;
-  value: string | null | undefined;
+  value: string | number | null | undefined;
   label: string;
   multiline?: boolean;
   className?: string;
   displayClassName?: string;
+  type?: 'text' | 'number';
 }) {
   const updateRecipe = useUpdateRecipe();
   const [isEditing, setIsEditing] = useState(false);
-  const [draft, setDraft] = useState(value ?? '');
+  const [draft, setDraft] = useState(String(value ?? ''));
   const [validationError, setValidationError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isEditing) {
-      setDraft(value ?? '');
+      setDraft(String(value ?? ''));
       setValidationError(null);
     }
   }, [isEditing, value]);
@@ -47,10 +49,21 @@ export function InlineEditableRecipeText({
 
     setValidationError(null);
 
-    const payload =
-      field === 'name'
-        ? ({ id: recipeId, name: nextValue } as Partial<RecipeDetail> & { id: string })
-        : ({ id: recipeId, [field]: nextValue || null } as Partial<RecipeDetail> & { id: string });
+    let payload: Partial<RecipeDetail> & { id: string };
+    
+    if (type === 'number') {
+      const numValue = nextValue === '' ? null : Number(nextValue);
+      if (nextValue !== '' && isNaN(numValue!)) {
+        setValidationError('Please enter a valid number.');
+        return;
+      }
+      payload = { id: recipeId, [field]: numValue } as Partial<RecipeDetail> & { id: string };
+    } else {
+      payload =
+        field === 'name'
+          ? ({ id: recipeId, name: nextValue } as Partial<RecipeDetail> & { id: string })
+          : ({ id: recipeId, [field]: nextValue || null } as Partial<RecipeDetail> & { id: string });
+    }
 
     updateRecipe.mutate(payload, {
         onSuccess: () => {
@@ -60,6 +73,8 @@ export function InlineEditableRecipeText({
       },
     );
   };
+
+  const displayValue = value ? (type === 'number' ? Math.round(Number(value)) : value) : null;
 
   return (
     <div className={cn('space-y-1', className)}>
@@ -80,6 +95,7 @@ export function InlineEditableRecipeText({
           ) : (
             <Input
               value={draft}
+              type={type}
               className={cn(field === 'name' && 'h-12 text-2xl font-semibold')}
               onChange={(event) => {
                 setDraft(event.target.value);
@@ -106,7 +122,7 @@ export function InlineEditableRecipeText({
               variant="outline"
               type="button"
               onClick={() => {
-                setDraft(value ?? '');
+                setDraft(String(value ?? ''));
                 setValidationError(null);
                 setIsEditing(false);
               }}
@@ -115,16 +131,16 @@ export function InlineEditableRecipeText({
             </Button>
           </div>
         </div>
-      ) : value ? (
+      ) : displayValue ? (
         <button
           type="button"
           onClick={() => setIsEditing(true)}
           className="block w-full text-left rounded-lg border border-transparent px-2 py-1 -mx-2 -my-1 hover:border-border hover:bg-muted/40 transition-colors"
         >
           {multiline ? (
-            <p className={cn('text-sm leading-relaxed whitespace-pre-line', displayClassName)}>{value}</p>
+            <p className={cn('text-sm leading-relaxed whitespace-pre-line', displayClassName)}>{displayValue}</p>
           ) : (
-            <p className={cn('text-sm font-medium', displayClassName)}>{value}</p>
+            <p className={cn('text-sm font-medium', displayClassName)}>{displayValue}</p>
           )}
         </button>
       ) : (

--- a/frontend/office/src/hooks/useRecipes.ts
+++ b/frontend/office/src/hooks/useRecipes.ts
@@ -105,11 +105,13 @@ export function useUpdateRecipe() {
       const { data } = await updateRecipe(id, updates);
       return data;
     },
-    onSuccess: (updatedRecipe) => {
+    onSuccess: (updatedRecipe, variables) => {
       queryClient.setQueryData([RECIPES_KEY, updatedRecipe.id], (oldData: any) => ({
         ...oldData,
+        ...variables,
         ...updatedRecipe,
       }));
+      queryClient.invalidateQueries({ queryKey: [RECIPES_KEY, updatedRecipe.id] });
       queryClient.invalidateQueries({
         queryKey: [RECIPES_KEY],
         predicate: (query) => typeof query.queryKey[1] === 'object',

--- a/frontend/office/src/pages/RecipeDetailPage.tsx
+++ b/frontend/office/src/pages/RecipeDetailPage.tsx
@@ -304,46 +304,54 @@ export function RecipeDetailPage() {
       {/* 1 column */}
       <div className="lg:col-span-3">
        <Section title="PREP TIME">
-        {recipe.preparation_time_minutes}
-        {(!recipe.preparation_time_minutes || recipe.preparation_time_minutes === 0) && (
-          <p className="text-sm text-muted-foreground italic">No preparation time minutes added yet.</p>
-          )}
+        <InlineEditableRecipeText
+          recipeId={recipe.id}
+          field="preparation_time_minutes"
+          value={recipe.preparation_time_minutes}
+          label=""
+          type="number"
+          displayClassName="text-lg"
+        />
        </Section>
       </div>
 
       {/* column 2 */}
       <div className="lg:col-span-3">
        <Section title="COOK TIME">
-        {recipe.cooking_time_minutes}
-        {(!recipe.cooking_time_minutes || recipe.cooking_time_minutes === 0) && (
-          <p className="text-sm text-muted-foreground italic">No cooking time minutes added yet.</p>
-          )}
+        <InlineEditableRecipeText
+          recipeId={recipe.id}
+          field="cooking_time_minutes"
+          value={recipe.cooking_time_minutes}
+          label=""
+          type="number"
+          displayClassName="text-lg"
+        />
        </Section>
       </div>
       {/* column 3 */}
       <div className="lg:col-span-3">
        <Section title="SERVINGS">
-        {/* Ternary operator for conditional rendering to ensure the math 
-        only happens if a valid value exists. */}
-        {recipe.portions_count_resolved ? (
-          // Only render the number if portion_size_grams is not null or empty
-          Math.round(Number(recipe.portions_count_resolved))
-        ) : (
-          // Fallback message if it is null, 0, or an empty string
-          <p className="text-sm text-muted-foreground italic">No portions count resolved added yet.</p>
-        )}
+        <InlineEditableRecipeText
+          recipeId={recipe.id}
+          field="portions_count_resolved"
+          value={recipe.portions_count_resolved}
+          label=""
+          type="number"
+          displayClassName="text-lg"
+        />
        </Section>
       </div>
       {/* column 4 */}
       <div className="lg:col-span-3">
        <Section title="PORTION SIZE">
-        {recipe.portion_size_grams ? (
-          Math.round(Number(recipe.portion_size_grams))
-        ) : (
-          <p className="text-sm text-muted-foreground italic">
-            No portion size grams resolved added yet.
-          </p>
-        )}
+        <InlineEditableRecipeText
+          recipeId={recipe.id}
+          field="portion_size_grams"
+          value={recipe.portion_size_grams}
+          label=""
+          type="number"
+          displayClassName="text-lg"
+        />
        </Section>
       </div>
     </div>
@@ -404,16 +412,6 @@ export function RecipeDetailPage() {
        </Section>
       </div>
     </div>
-
-         {/* ── Identity ───────────────────────────────────────── */}
-      <Section title="Identity">
-        <Grid>
-          <DetailRow label="ID" value={recipe.id} />
-          <DetailRow label="Is component" value={recipe.is_component} />
-          <DetailRow label="Created" value={formatDatetime(recipe.created_at)} />
-          <DetailRow label="Updated" value={formatDatetime(recipe.updated_at)} />
-        </Grid>
-      </Section>
       {/* <Section title="yield_mode">
         yield_mode
       </Section> */}
@@ -426,11 +424,39 @@ export function RecipeDetailPage() {
       {/* ── Yield & Weights ────────────────────────────────── */}
       <Section title="Yield & Weights">
           <Grid>
-            {/* <DetailRow label="Yield" value={recipe.yield_amount != null ? `${recipe.yield_amount}${recipe.yield_unit ? ` ${recipe.yield_unit}` : ''}` : null} /> */}
-            {/* <DetailRow label="Reduction factor" value={recipe.reduction_factor} /> */}
-            <DetailRow label="Total cooked weight (g)" value={recipe.total_cooked_weight_grams} />
+            <div>
+              <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Total raw weight (g)</p>
+              <InlineEditableRecipeText
+                recipeId={recipe.id}
+                field="total_raw_weight_grams"
+                value={recipe.total_raw_weight_grams}
+                label=""
+                type="number"
+                displayClassName="text-sm"
+              />
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Total cooked weight (g)</p>
+              <InlineEditableRecipeText
+                recipeId={recipe.id}
+                field="total_cooked_weight_grams"
+                value={recipe.total_cooked_weight_grams}
+                label=""
+                type="number"
+                displayClassName="text-sm"
+              />
+            </div>
           </Grid>
         </Section>
+                 {/* ── Identity ───────────────────────────────────────── */}
+      <Section title="Identity">
+        <Grid>
+          <DetailRow label="ID" value={recipe.id} />
+          <DetailRow label="Is component" value={recipe.is_component} />
+          <DetailRow label="Created" value={formatDatetime(recipe.created_at)} />
+          <DetailRow label="Updated" value={formatDatetime(recipe.updated_at)} />
+        </Grid>
+      </Section>
     </div>
   );
 }


### PR DESCRIPTION
This pull request enhances the `InlineEditableRecipeText` component and updates the `RecipeDetailPage` to allow inline editing of several numeric recipe fields (such as preparation time, cooking time, portions, and weights). The changes improve user experience by enabling direct editing of these fields with proper validation, replacing static or conditional displays.

**Component enhancements:**

- Extended the `EditableRecipeField` type and the `InlineEditableRecipeText` component to support additional numeric fields (`preparation_time_minutes`, `cooking_time_minutes`, `portion_size_grams`, `portions_count_resolved`, `total_raw_weight_grams`, `total_cooked_weight_grams`, `yield_mode`). The component now accepts both string and number values, and includes a `type` prop to distinguish between text and number inputs. Numeric input is validated and converted appropriately. [[1]](diffhunk://#diff-ac01d5ad52e45ba6a568fce3bd6fb99853e25958e9a7e265889b627a1468cfeeL9-R9) [[2]](diffhunk://#diff-ac01d5ad52e45ba6a568fce3bd6fb99853e25958e9a7e265889b627a1468cfeeR19-R37) [[3]](diffhunk://#diff-ac01d5ad52e45ba6a568fce3bd6fb99853e25958e9a7e265889b627a1468cfeeL50-R66) [[4]](diffhunk://#diff-ac01d5ad52e45ba6a568fce3bd6fb99853e25958e9a7e265889b627a1468cfeeR77-R78) [[5]](diffhunk://#diff-ac01d5ad52e45ba6a568fce3bd6fb99853e25958e9a7e265889b627a1468cfeeR98) [[6]](diffhunk://#diff-ac01d5ad52e45ba6a568fce3bd6fb99853e25958e9a7e265889b627a1468cfeeL109-R125) [[7]](diffhunk://#diff-ac01d5ad52e45ba6a568fce3bd6fb99853e25958e9a7e265889b627a1468cfeeL118-R143)

**UI improvements in recipe detail page:**

- Replaced static and conditional rendering of numeric fields (prep time, cook time, servings, portion size) with the new inline-editable component, allowing users to edit these values directly in the UI.
- Added inline-editable fields for "Total raw weight (g)" and "Total cooked weight (g)" in the "Yield & Weights" section, improving consistency and editability of recipe metrics.
- Refactored the placement of the "Identity" section for better organization after the yield/weights section. [[1]](diffhunk://#diff-0d205fb80bbec58ffe58c6642e9d76887b193d1fb183f2da156ff6b7a4189a75L407-L416) [[2]](diffhunk://#diff-0d205fb80bbec58ffe58c6642e9d76887b193d1fb183f2da156ff6b7a4189a75L429-R457)